### PR TITLE
7 refactor for better image format handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
 			<artifactId>webp-imageio-sejda</artifactId>
 			<version>0.1.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.tika</groupId>
+			<artifactId>tika-core</artifactId>
+			<version>2.9.2</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
 			<type>POM</type>
 		</dependency>
 		<dependency>
+			<groupId>org.jcodec</groupId>
+			<artifactId>jcodec</artifactId>
+			<version>0.2.5</version>
+		</dependency>
+		<dependency>
 			<groupId>org.sejda.webp-imageio</groupId>
 			<artifactId>webp-imageio-sejda</artifactId>
 			<version>0.1.0</version>
@@ -60,6 +65,11 @@
 			<groupId>org.apache.tika</groupId>
 			<artifactId>tika-core</artifactId>
 			<version>2.9.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-swing</artifactId>
+			<version>23</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
@@ -4,7 +4,7 @@ public class ImageTemplate {
     private int width = 600;
     private int height = 400;
     private String newImageName = "test-editing";
-    private String format = "webp";
+    private String format = "jpg";
 
     public void setHeight(int height) {
         this.height = height;

--- a/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
@@ -5,8 +5,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.nio.file.Path;
 
-import javax.imageio.ImageIO;
-
 import org.springframework.stereotype.Component;
 
 import com.gregorybroche.imageresolver.classes.ImageTemplate;
@@ -29,8 +27,7 @@ public class MainController {
     private ValidatorService validatorService;
     private ImageEditorService imageEditorService;
     private ResolverProcessorService resolverProcessorService;
-    private Image imageToResolve = null;
-    private Path imageToResolveTempPath = null;
+    private File imageToResolve = null;
 
     public MainController(  UserDialogService userDialogService,
                             FileHandlerService fileHandlerService,
@@ -61,10 +58,9 @@ public class MainController {
                 this.userDialogService.showInvalidSelectedFileFormatError();
                 return;
             }
-            Path savedFilePath = fileHandlerService.saveFileToTemp(selectedFile);
-            this.imageToResolveTempPath = savedFilePath;
-            this.imageToResolve = this.getImageFromFilePath(savedFilePath);
-            this.displaySelectedImagePreview(this.imageToResolve);
+            this.imageToResolve = fileHandlerService.saveFileToTemp(selectedFile).toFile();
+            Image previewImage = getImageFromFilePath(imageToResolve.toPath());
+            this.displaySelectedImagePreview(previewImage);
         } catch (Exception e) {
             userDialogService.showErrorMessage("failed to select image", e.getMessage());
             throw new RuntimeException(e);
@@ -74,7 +70,7 @@ public class MainController {
     @FXML
     void resolveImage(MouseEvent event) {
         try{
-            BufferedImage sourceBufferedImage = imageEditorService.getImageContentFromFile(imageToResolveTempPath.toFile());
+            BufferedImage sourceBufferedImage = imageEditorService.getImageContentFromFile(imageToResolve);
             ImageTemplate template = getTemplateParameters();
             Path directory = fileHandlerService.getAppDirectoryPath(); //Temporary for testing until logic for defining templates and presets through inputs is done
             resolverProcessorService.processImageForTemplate(sourceBufferedImage, template, directory);

--- a/src/main/java/com/gregorybroche/imageresolver/service/ImageEditorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/ImageEditorService.java
@@ -4,8 +4,6 @@ import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.util.Set;
-
 import javax.imageio.ImageIO;
 
 import org.springframework.stereotype.Service;
@@ -15,24 +13,50 @@ import com.gregorybroche.imageresolver.classes.ImageTemplate;
 @Service
 public class ImageEditorService {
     private ValidatorService validatorService;
-    public ImageEditorService(ValidatorService validatorService){
+    private UserDialogService userDialogService;
+    public ImageEditorService(ValidatorService validatorService, UserDialogService userDialogService){
         this.validatorService = validatorService;
+        this.userDialogService = userDialogService;
     }
+
+    /**
+     * Gets content of an image file if the file is supported
+     * @param imageFile source image file
+     * @return BufferedImage content or null if error
+     */
+    public BufferedImage getImageContentFromFile(File imageFile){
+        if(!validatorService.isFileValidImageFormat(imageFile)){
+            userDialogService.showErrorMessage("Invalid format", "The format of the file used is not a supported image format");
+            return null;
+        }
+        try {
+            BufferedImage imageContent = ImageIO.read(imageFile);
+            return imageContent;
+        } catch (Exception e) {
+            userDialogService.showErrorMessage("Image extraction error", "The content of the source image file could not be extracted");
+            return null;
+        }
+        
+    }
+
     /**
      * Takes an image content and creates a new image content based on it and defined template to apply
      * @param baseImageContent buffered image content of a source image
      * @param templateParameters parameters as instance of ImageTemplate
      * @return new buffered image content based on inputs given
      */
-    public BufferedImage editImage(BufferedImage baseImageContent, ImageTemplate templateParameters){
+    public BufferedImage editImage(BufferedImage baseImageContent, ImageTemplate templateParameters, Integer finalBufferedImageColorType){
         int targetWidth = templateParameters.getWidth();
         int targetHeight = templateParameters.getHeight();
-        Image editedImage = baseImageContent.getScaledInstance(targetWidth, targetHeight, Image.SCALE_SMOOTH);
-        BufferedImage outputImage = new BufferedImage(targetWidth, targetHeight, BufferedImage.TYPE_INT_RGB);
+        Image editedImage = baseImageContent.getScaledInstance(targetWidth, targetHeight, Image.SCALE_AREA_AVERAGING);
+        BufferedImage outputImage = new BufferedImage(targetWidth, targetHeight, finalBufferedImageColorType);
         outputImage.getGraphics().drawImage(editedImage, 0, 0, null);
         return outputImage;
     }
 
+    /**
+     * creates a basic BufferedImage object to use for testing purpose
+     */
     public BufferedImage createTestImageContent() {
         BufferedImage bufferedImage = new BufferedImage(100, 100, BufferedImage.TYPE_INT_RGB);
         for (int x = 0; x < 100; x++) {
@@ -43,52 +67,44 @@ public class ImageEditorService {
         return bufferedImage;
     }
 
-    public void createImage(File imageFile, String extension, BufferedImage bufferedImageContent) throws IOException{
-        Set<String> allowedExtensions = validatorService.getAllowedImageFormatsAsExtension();
-        if(!allowedExtensions.contains(extension)){
-            String errorMessage = "Invalid format requested: requested "+extension+" not in allowed formats ("+validatorService.getAllowedImageFormatsAsString()+")";
-            throw new IOException(errorMessage);
-        }
-        switch (extension) {
-            case "jpg":
-                createJPGImage(imageFile, bufferedImageContent);
-                break;
-        
-            case "jpeg":
-                createJPEGImage(imageFile, bufferedImageContent);
-                break;
-        
-            case "png":
-                createPNGImage(imageFile, bufferedImageContent);
-                break;
-        
-            case "bmp":
-                createBMPImage(imageFile, bufferedImageContent);
-                break;
-        
-            case "webp":
-                createWEBPImage(imageFile, bufferedImageContent);
-                break;
-        
-            default:
-                ImageIO.write(bufferedImageContent, extension, imageFile);
-                break;
-        } 
-    }
+    /*
+     * Image format specific methods to further specify writer parameters if required
+     */
 
-    public void createJPGImage(File imageFile, BufferedImage bufferedImageContent) throws IOException{
-        ImageIO.write(bufferedImageContent, "jpg", imageFile);
+    public void createJPGImage(BufferedImage bufferedImageContent, File imageFile) throws IOException{
+        Boolean result = ImageIO.write(bufferedImageContent, "jpg", imageFile);
+        if (!result){
+            throw new IOException("Could not save image with name \""+imageFile.getName()+"\"");
+        }
     }
-    public void createJPEGImage(File imageFile, BufferedImage bufferedImageContent) throws IOException{
-        ImageIO.write(bufferedImageContent, "jpeg", imageFile);
+    public void createJPEGImage(BufferedImage bufferedImageContent, File imageFile) throws IOException{
+        Boolean result = ImageIO.write(bufferedImageContent, "jpeg", imageFile);
+        if (!result){
+            throw new IOException("Could not save image with name \""+imageFile.getName()+"\"");
+        }
     }
-    public void createPNGImage(File imageFile, BufferedImage bufferedImageContent) throws IOException{
-        ImageIO.write(bufferedImageContent, "png", imageFile);
+    public void createPNGImage(BufferedImage bufferedImageContent, File imageFile) throws IOException{
+        Boolean result = ImageIO.write(bufferedImageContent, "png", imageFile);
+        if (!result){
+            throw new IOException("Could not save image with name \""+imageFile.getName()+"\"");
+        }
     }
-    public void createBMPImage(File imageFile, BufferedImage bufferedImageContent) throws IOException{
-        ImageIO.write(bufferedImageContent, "bmp", imageFile);
+    public void createBMPImage(BufferedImage bufferedImageContent, File imageFile) throws IOException{
+        Boolean result = ImageIO.write(bufferedImageContent, "bmp", imageFile);
+        if (!result){
+            throw new IOException("Could not save image with name \""+imageFile.getName()+"\"");
+        }
     }
-    public void createWEBPImage(File imageFile, BufferedImage bufferedImageContent) throws IOException{
-        ImageIO.write(bufferedImageContent, "webp", imageFile);
+    public void createWEBPImage(BufferedImage bufferedImageContent, File imageFile) throws IOException{
+        Boolean result = ImageIO.write(bufferedImageContent, "webp", imageFile);
+        if (!result){
+            throw new IOException("Could not save image with name \""+imageFile.getName()+"\"");
+        }
+    }
+    public void createImage(BufferedImage bufferedImageContent, String format, File imageFile) throws IOException{
+        Boolean result = ImageIO.write(bufferedImageContent, format, imageFile);
+        if (!result){
+            throw new IOException("Could not save image with name \""+imageFile.getName()+"\"");
+        }
     }
 }

--- a/src/main/java/com/gregorybroche/imageresolver/service/ImageEditorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/ImageEditorService.java
@@ -36,7 +36,6 @@ public class ImageEditorService {
             userDialogService.showErrorMessage("Image extraction error", "The content of the source image file could not be extracted");
             return null;
         }
-        
     }
 
     /**

--- a/src/main/java/com/gregorybroche/imageresolver/service/ResolverProcessorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/ResolverProcessorService.java
@@ -5,8 +5,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import javax.imageio.ImageIO;
-
 import org.springframework.stereotype.Service;
 
 import com.gregorybroche.imageresolver.classes.ImageTemplate;

--- a/src/main/java/com/gregorybroche/imageresolver/service/ResolverProcessorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/ResolverProcessorService.java
@@ -1,0 +1,77 @@
+package com.gregorybroche.imageresolver.service;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import javax.imageio.ImageIO;
+
+import org.springframework.stereotype.Service;
+
+import com.gregorybroche.imageresolver.classes.ImageTemplate;
+
+@Service
+public class ResolverProcessorService {
+    private ImageEditorService imageEditorService;
+    private FileHandlerService fileHandlerService;
+    private ValidatorService validatorService;
+
+    public ResolverProcessorService(ImageEditorService imageEditorService, FileHandlerService fileHandlerService, ValidatorService validatorService){
+        this.validatorService = validatorService;
+        this.fileHandlerService = fileHandlerService;
+        this.imageEditorService = imageEditorService;
+    }
+
+    /**
+     * Method to handle the process of resizing the source image and then saving the result in a new image file based on a given template 
+     * @param sourceImageContent BufferedImage content of the source image
+     * @param imageTemplate Instance of ImageTemplate qui specification for the edited image to create
+     * @param saveToDirectory Path instance of the directory where the edit image must be saved
+     * @throws IOException
+     */
+    public void processImageForTemplate(BufferedImage sourceImageContent, ImageTemplate imageTemplate, Path saveToDirectory) throws IOException{
+
+        String templateExtension = imageTemplate.getFormat();
+        if(!validatorService.isExtensionValid(templateExtension)){
+            String errorMessage = "Invalid format requested: requested "+templateExtension+" not in allowed formats ("+validatorService.getAllowedImageFormatsAsString()+")";
+            throw new IOException(errorMessage);
+        }
+
+        File editedImageFile = fileHandlerService.setFileToSaveTo(imageTemplate, saveToDirectory);
+        BufferedImage editedImageContent;
+        
+        switch (templateExtension) {
+            case "jpg":
+                editedImageContent = imageEditorService.editImage(sourceImageContent, imageTemplate, BufferedImage.TYPE_INT_RGB);
+                imageEditorService.createJPGImage(editedImageContent, editedImageFile);
+                break;
+        
+            case "jpeg":
+                editedImageContent = imageEditorService.editImage(sourceImageContent, imageTemplate, BufferedImage.TYPE_INT_RGB);
+                imageEditorService.createJPEGImage(editedImageContent, editedImageFile);
+                break;
+                
+            case "bmp":
+                editedImageContent = imageEditorService.editImage(sourceImageContent, imageTemplate, BufferedImage.TYPE_INT_RGB);
+                imageEditorService.createBMPImage(editedImageContent, editedImageFile);
+                break;
+
+            case "png":
+                editedImageContent = imageEditorService.editImage(sourceImageContent, imageTemplate, BufferedImage.TYPE_INT_ARGB);
+                imageEditorService.createPNGImage(editedImageContent, editedImageFile);
+                break;
+
+        
+            case "webp":
+                editedImageContent = imageEditorService.editImage(sourceImageContent, imageTemplate, BufferedImage.TYPE_INT_ARGB);
+                imageEditorService.createWEBPImage(editedImageContent, editedImageFile);
+                break;
+        
+            default:
+                editedImageContent = imageEditorService.editImage(sourceImageContent, imageTemplate, BufferedImage.TYPE_INT_RGB);
+                imageEditorService.createImage(editedImageContent, templateExtension, editedImageFile);
+                break;
+        }
+    }
+}

--- a/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
@@ -19,7 +19,7 @@ public class ValidatorService {
      * @param file file to validate
      * @return true if file complies, false otherwise
      */
-    public Boolean isFileValidImageFormat(File file){
+    public Boolean isFileValidImageFormat(File file) {
         try {
             String mimeType = Files.probeContentType(file.toPath());
             if (mimeType == null || !this.allowedImageMimeTypes.contains(mimeType)) {
@@ -27,8 +27,12 @@ public class ValidatorService {
             }
             return true;
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            return false;
         }
+    }
+
+    public Boolean isExtensionValid(String extension){
+        return getAllowedImageFormatsAsExtension().contains(extension);
     }
 
     /**

--- a/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
@@ -1,18 +1,19 @@
 package com.gregorybroche.imageresolver.service;
 
 import java.io.File;
-import java.nio.file.Files;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.tika.Tika;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ValidatorService {
-    private final List<String> allowedImageFormats = Arrays.asList("*.jpg", "*.jpeg", "*.png", "*.bmp", "*.webp");
-    private final List<String> allowedImageMimeTypes = Arrays.asList("image/jpeg", "image/png", "image/bmp", "image/webp");
+    private final List<String> allowedImageFormats = Arrays.asList("*.jpg", "*.jpeg", "*.png", "*.bmp", "*.webp", "*.avif");
+    private final List<String> allowedImageMimeTypes = Arrays.asList("image/jpeg", "image/png", "image/bmp", "image/webp", "image/avif");
 
     /**
      * Validate that a file mime type complies with allowed mime types. 
@@ -21,7 +22,7 @@ public class ValidatorService {
      */
     public Boolean isFileValidImageFormat(File file) {
         try {
-            String mimeType = Files.probeContentType(file.toPath());
+            String mimeType = getFileMimeType(file);
             if (mimeType == null || !this.allowedImageMimeTypes.contains(mimeType)) {
                 return false;
             }
@@ -29,6 +30,11 @@ public class ValidatorService {
         } catch (Exception e) {
             return false;
         }
+    }
+
+    public String getFileMimeType(File file) throws IOException {
+        Tika tika = new Tika();
+        return tika.detect(file);
     }
 
     public Boolean isExtensionValid(String extension){

--- a/src/test/java/com/gregorybroche/imageresolver/service/FileHandlerServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/FileHandlerServiceTest.java
@@ -52,10 +52,11 @@ public class FileHandlerServiceTest {
     @BeforeEach
     void setUp() throws IOException {
         ValidatorService validatorService = new ValidatorService();
-        imageEditorService = new ImageEditorService(validatorService);
+        UserDialogService userDialogService = new UserDialogService(validatorService);
+        imageEditorService = new ImageEditorService(validatorService, userDialogService);
         fileHandlerService = new FileHandlerService(
                 applicationContext,
-                imageEditorService,
+                userDialogService,
                 mainDirectoryName,
                 tempDirectoryName,
                 presetFileName,
@@ -176,7 +177,7 @@ public class FileHandlerServiceTest {
             System.out.println(imageEditorService);
             // creating valid image for testing
             File testImageFile = File.createTempFile("testValidImage", ".png");
-            imageEditorService.createPNGImage(testImageFile, testImageBufferedContent);
+            imageEditorService.createPNGImage(testImageBufferedContent, testImageFile);
 
             assertFalse(Files.exists(testTempDirectory));
 

--- a/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
@@ -27,7 +27,8 @@ public class ValidatorServiceTest {
     @BeforeEach
     void setUp(){
         validatorService = new ValidatorService(); 
-        imageEditorService = new ImageEditorService(validatorService);
+        UserDialogService userDialogService = new UserDialogService(validatorService);
+        imageEditorService = new ImageEditorService(validatorService, userDialogService);
         ReflectionTestUtils.setField(validatorService, "allowedImageMimeTypes", testAllowedImageMimeTypes);
         ReflectionTestUtils.setField(validatorService, "allowedImageFormats", testAllowedImageFormats);
         testImageBufferedContent = imageEditorService.createTestImageContent();
@@ -71,7 +72,7 @@ public class ValidatorServiceTest {
     void isFileValidImageFormat_fileAsPNG_ShouldReturnTrue() {
         try {
             File testPNGFile = tempDir.resolve("testImage.png").toFile();
-            imageEditorService.createPNGImage(testPNGFile, testImageBufferedContent);
+            imageEditorService.createPNGImage(testImageBufferedContent, testPNGFile);
             assertTrue(validatorService.isFileValidImageFormat(testPNGFile));
         } catch (Exception e) {
             fail("Exception triggered " + e.getMessage());
@@ -82,7 +83,7 @@ public class ValidatorServiceTest {
     void isFileValidImageFormat_fileAsJPG_ShouldReturnTrue() {
         try {
             File testJPGFile = tempDir.resolve("testImage.jpg").toFile();
-            imageEditorService.createPNGImage(testJPGFile, testImageBufferedContent);
+            imageEditorService.createPNGImage(testImageBufferedContent, testJPGFile);
             assertTrue(validatorService.isFileValidImageFormat(testJPGFile));
         } catch (Exception e) {
             fail("Exception triggered " + e.getMessage());
@@ -93,7 +94,7 @@ public class ValidatorServiceTest {
     void isFileValidImageFormat_fileAsJPEG_ShouldReturnTrue() {
         try {
             File testJPEGFile = tempDir.resolve("testImage.jpeg").toFile();
-            imageEditorService.createPNGImage(testJPEGFile, testImageBufferedContent);
+            imageEditorService.createPNGImage(testImageBufferedContent, testJPEGFile);
             assertTrue(validatorService.isFileValidImageFormat(testJPEGFile));
         } catch (Exception e) {
             fail("Exception triggered " + e.getMessage());
@@ -104,7 +105,7 @@ public class ValidatorServiceTest {
     void isFileValidImageFormat_fileAsBMP_ShouldReturnTrue() {
         try {
             File testBMPFile = tempDir.resolve("testImage.bmp").toFile();
-            imageEditorService.createPNGImage(testBMPFile, testImageBufferedContent);
+            imageEditorService.createPNGImage(testImageBufferedContent, testBMPFile);
             assertTrue(validatorService.isFileValidImageFormat(testBMPFile));
         } catch (Exception e) {
             fail("Exception triggered " + e.getMessage());
@@ -114,7 +115,7 @@ public class ValidatorServiceTest {
     void isFileValidImageFormat_fileAsWEBP_ShouldReturnTrue() {
         try {
             File testWEBPFile = tempDir.resolve("testImage.webp").toFile();
-            imageEditorService.createPNGImage(testWEBPFile, testImageBufferedContent);
+            imageEditorService.createPNGImage(testImageBufferedContent, testWEBPFile);
             assertTrue(validatorService.isFileValidImageFormat(testWEBPFile));
         } catch (Exception e) {
             fail("Exception triggered " + e.getMessage());

--- a/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
@@ -15,8 +15,9 @@ import org.junit.jupiter.api.io.TempDir;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class ValidatorServiceTest {
-    private final List<String> testAllowedImageFormats = Arrays.asList("*.jpg", "*.jpeg", "*.png", "*.bmp", "*.webp");
-    private final List<String> testAllowedImageMimeTypes = Arrays.asList("image/jpeg", "image/png", "image/bmp", "image/webp");
+    private final List<String> testAllowedImageFormats = Arrays.asList("*.jpg", "*.jpeg", "*.png", "*.bmp", "*.webp", "*.avif");
+    private final String expectedStringifiedValue = ".jpg, .jpeg, .png, .bmp, .webp, .avif";
+    private final List<String> testAllowedImageMimeTypes = Arrays.asList("image/jpeg", "image/png", "image/bmp", "image/webp", "image/avif");
     ValidatorService validatorService;
     ImageEditorService imageEditorService;
     BufferedImage testImageBufferedContent;
@@ -56,7 +57,6 @@ public class ValidatorServiceTest {
     @Test
     void getAllowedImageFormatsAsString_shouldReturnStringInExpectedFormat() {
         try {
-            String expectedStringifiedValue = ".jpg, .jpeg, .png, .bmp, .webp";
             String allowedFormatResultAsString = this.validatorService.getAllowedImageFormatsAsString();
             assertTrue(allowedFormatResultAsString.equals(expectedStringifiedValue), "Should return string: "+expectedStringifiedValue);
         } catch (Exception e) {


### PR DESCRIPTION
Did some refactoring to better enclose some of the existing logic inside dedicated services and methods to make later adjustement easier, especially those that may be related to handling format specific parameters.
Allowed .avif format considering it's a format i want to handle. However at this point there doesn't seem to be a convenient way to extract a BufferedImage from this type of file so a workaround will be needed (possibly through ffmpeg?).
Changed the method to get the mime type of a file to using org.apache.tika since the previous implementation using Files.probeContentType would return null for avif (probably because mime recognition is environment dependant, so this would be a broader concern than just avif and create inconsistent behaviors)