### PR TITLE
9 implement adding templates to a preset

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.1</version>
+		<version>3.3.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.gregorybroche</groupId>

--- a/src/main/java/com/gregorybroche/imageresolver/Enums/ConstraintType.java
+++ b/src/main/java/com/gregorybroche/imageresolver/Enums/ConstraintType.java
@@ -1,0 +1,9 @@
+package com.gregorybroche.imageresolver.Enums;
+
+public enum ConstraintType {
+    REQUIRED,
+    GREATER_THAN,
+    LESS_THAN,
+    LONGER_THAN,
+    SHORTER_THAN
+}

--- a/src/main/java/com/gregorybroche/imageresolver/Enums/ConstraintType.java
+++ b/src/main/java/com/gregorybroche/imageresolver/Enums/ConstraintType.java
@@ -5,5 +5,6 @@ public enum ConstraintType {
     GREATER_THAN,
     LESS_THAN,
     LONGER_THAN,
-    SHORTER_THAN
+    SHORTER_THAN,
+    INCLUDED_IN
 }

--- a/src/main/java/com/gregorybroche/imageresolver/Enums/ConstraintType.java
+++ b/src/main/java/com/gregorybroche/imageresolver/Enums/ConstraintType.java
@@ -2,6 +2,7 @@ package com.gregorybroche.imageresolver.Enums;
 
 public enum ConstraintType {
     REQUIRED,
+    IS_INTEGER_STRING,
     GREATER_THAN,
     LESS_THAN,
     LONGER_THAN,

--- a/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
@@ -99,7 +99,7 @@ public class ImageTemplate {
      * Creates and returns the FXML component view with data corresponding to this instance of ImageTemplate
      * @return
      */
-    public HBox createTemplatePane(Integer indexInPreset) {
+    public HBox createTemplateComponent(Integer indexInPreset) {
         try {
             FXMLLoader loader = new FXMLLoader(getClass().getResource("../views/templateComponent.fxml"));
             HBox templatePane = loader.load();

--- a/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
@@ -1,6 +1,8 @@
 package com.gregorybroche.imageresolver.classes;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.gregorybroche.imageresolver.controller.TemplateItemController;
 
@@ -17,6 +19,12 @@ public class ImageTemplate {
     private String newImageSuffix = "-post";
     private String format = "jpg";
     private int defaultResolution = 90;
+
+    private static final Map<String, InputConstraint[]> formConstraints = new HashMap<String, InputConstraint[]>();
+
+    //filling up rules
+    static {
+    }
 
     public ImageTemplate(String templateName,
                         int width,

--- a/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
@@ -1,10 +1,6 @@
 package com.gregorybroche.imageresolver.classes;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
-import com.gregorybroche.imageresolver.Enums.ConstraintType;
 import com.gregorybroche.imageresolver.controller.TemplateItemController;
 
 import javafx.fxml.FXMLLoader;
@@ -20,12 +16,6 @@ public class ImageTemplate {
     private String newImageSuffix = "-post";
     private String format = "jpg";
     private int defaultResolution = 90;
-
-    
-
-    //filling up rules
-    static {
-    }
 
     public ImageTemplate(String templateName,
                         int width,

--- a/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
@@ -16,9 +16,28 @@ public class ImageTemplate {
     private String newImageBaseName = "test_editing";
     private String newImageSuffix = "-post";
     private String format = "jpg";
+    private int defaultResolution = 90;
+
+    public ImageTemplate(String templateName,
+                        int width,
+                        int height,
+                        Integer resolution,
+                        String newImagePrefix,
+                        String newImageBaseName,
+                        String newImageSuffix,
+                        String format){
+        setTemplateName(templateName);
+        setWidth(width);
+        setHeight(height);
+        setResolution(resolution);
+        setNewImagePrefix(newImagePrefix);
+        setNewImageBaseName(newImageBaseName);
+        setNewImageSuffix(newImageSuffix);
+        setFormat(format);
+    }
 
     public void setTemplateName(String templateName) {
-        this.templateName = templateName;
+        this.templateName = templateName.length() > 0 ? templateName : "unnamed template";
     }
     public String getTemplateName() {
         return this.templateName;
@@ -38,15 +57,15 @@ public class ImageTemplate {
         return this.width;
     }
 
-    public void setResolution(int resolution) {
-        this.resolution = resolution;
+    public void setResolution(Integer resolution) {
+        this.resolution = resolution != null ? resolution : this.defaultResolution;
     }
     public int getResolution() {
         return this.resolution;
     }
 
     public void setNewImagePrefix(String prefix) {
-        this.newImagePrefix = prefix;
+        this.newImagePrefix = prefix.length() > 0 ? prefix : "";
     }
     public String getNewImagePrefix() {
         return this.newImagePrefix;
@@ -60,7 +79,7 @@ public class ImageTemplate {
     }
 
     public void setNewImageSuffix(String suffix) {
-        this.newImageSuffix = suffix;
+        this.newImageSuffix = suffix.length() > 0 ? suffix : "";
     }
     public String getNewImageSuffix() {
         return this.newImageSuffix;

--- a/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.gregorybroche.imageresolver.Enums.ConstraintType;
 import com.gregorybroche.imageresolver.controller.TemplateItemController;
 
 import javafx.fxml.FXMLLoader;
@@ -20,7 +21,7 @@ public class ImageTemplate {
     private String format = "jpg";
     private int defaultResolution = 90;
 
-    private static final Map<String, InputConstraint[]> formConstraints = new HashMap<String, InputConstraint[]>();
+    
 
     //filling up rules
     static {

--- a/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
@@ -64,7 +64,7 @@ public class ImageTemplate {
     }
 
     public void setNewImagePrefix(String prefix) {
-        this.newImagePrefix = prefix.length() > 0 ? prefix : "";
+        this.newImagePrefix = prefix == null || prefix.length() == 0 ? "" : prefix;
     }
     public String getNewImagePrefix() {
         return this.newImagePrefix;
@@ -78,7 +78,7 @@ public class ImageTemplate {
     }
 
     public void setNewImageSuffix(String suffix) {
-        this.newImageSuffix = suffix.length() > 0 ? suffix : "";
+        this.newImageSuffix = suffix == null || suffix.length() == 0 ? "" : suffix;
     }
     public String getNewImageSuffix() {
         return this.newImageSuffix;

--- a/src/main/java/com/gregorybroche/imageresolver/classes/InputConstraint.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/InputConstraint.java
@@ -1,0 +1,37 @@
+package com.gregorybroche.imageresolver.classes;
+
+import com.gregorybroche.imageresolver.Enums.ConstraintType;
+
+/**
+ * Class intended to by used to define constraints for user submitted inputs
+ */
+
+public class InputConstraint {
+    private String constraintName;
+    private ConstraintType constraintType;
+    private Object value;
+    private String errorMessage;
+
+    public InputConstraint(String constraintName, ConstraintType ConstraintType, Object value, String errorMessage) {
+        this.constraintName = constraintName;
+        this.constraintType = ConstraintType;
+        this.value = value;
+        this.errorMessage = errorMessage;
+    }
+
+    public String getConstraintName() {
+        return this.constraintName;
+    }
+
+    public ConstraintType getConstraintType() {
+        return this.constraintType;
+    }
+
+    public Object getValue() {
+        return this.value;
+    }
+
+    public String getErrorMessage() {
+        return this.errorMessage;
+    }
+}

--- a/src/main/java/com/gregorybroche/imageresolver/classes/Preset.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/Preset.java
@@ -1,0 +1,34 @@
+package com.gregorybroche.imageresolver.classes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Preset {
+    private String name;
+    private List<ImageTemplate> templates = new ArrayList<ImageTemplate>();
+
+    public Preset(String presetName){
+        setName(presetName);
+    }
+
+    public void setName(String presetName) {
+        this.name = presetName.length() > 0 ? presetName : "unnamed preset";
+    }
+    public String getTemplateName() {
+        return this.name;
+    }
+
+    public List<ImageTemplate> getTemplates() {
+        return this.templates;
+    }
+
+    public boolean addTemplate(ImageTemplate imageTemplate){
+        try {
+            this.templates.add(imageTemplate);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/com/gregorybroche/imageresolver/classes/Preset.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/Preset.java
@@ -15,6 +15,7 @@ public class Preset {
     public void setName(String presetName) {
         this.name = presetName.length() > 0 ? presetName : "unnamed preset";
     }
+
     public String getName() {
         return this.name;
     }
@@ -22,14 +23,27 @@ public class Preset {
     public void setTemplates(List<ImageTemplate> templates) {
         this.templates = templates;
     }
+
     public List<ImageTemplate> getTemplates() {
         return this.templates;
     }
 
+    public boolean isTemplateNameAlreadyPresent(String name) {
+        for (ImageTemplate template : templates) {
+            if (template.getTemplateName().equals(name)){
+                return true;
+            }
+        }
+        return false;
+    }
+
     public boolean addTemplate(ImageTemplate imageTemplate){
         try {
+            if(isTemplateNameAlreadyPresent(imageTemplate.getTemplateName())){
+                return false;
+            }
             this.templates.add(imageTemplate);
-            return true;
+            return this.templates.getLast().getTemplateName().equals(imageTemplate.getTemplateName());
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/com/gregorybroche/imageresolver/classes/Preset.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/Preset.java
@@ -7,17 +7,21 @@ public class Preset {
     private String name;
     private List<ImageTemplate> templates = new ArrayList<ImageTemplate>();
 
-    public Preset(String presetName){
+    public Preset(String presetName, List<ImageTemplate> templates){
         setName(presetName);
+        setTemplates(templates);
     }
 
     public void setName(String presetName) {
         this.name = presetName.length() > 0 ? presetName : "unnamed preset";
     }
-    public String getTemplateName() {
+    public String getName() {
         return this.name;
     }
 
+    public void setTemplates(List<ImageTemplate> templates) {
+        this.templates = templates;
+    }
     public List<ImageTemplate> getTemplates() {
         return this.templates;
     }

--- a/src/main/java/com/gregorybroche/imageresolver/classes/ValidationResponse.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/ValidationResponse.java
@@ -1,0 +1,33 @@
+package com.gregorybroche.imageresolver.classes;
+
+public class ValidationResponse {
+    private boolean isSuccess;
+    private Object[] data;
+    private String message;
+
+    public ValidationResponse(boolean isSuccess, Object[] data, String message){
+        this.isSuccess = isSuccess;
+        this.data = data;
+        this.message = message;
+    }
+
+    public boolean getIsSuccess(){
+        return this.isSuccess;
+    }
+
+    public Object[] getData(){
+        return this.data;
+    }
+
+    public String getMessage(){
+        return this.message;
+    }
+
+    public boolean isDataNull(){
+        return this.data == null;
+    }
+
+    public boolean isMessageNull(){
+        return this.message == null;
+    }
+}

--- a/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
@@ -107,8 +107,8 @@ public class MainController {
             Parent root = loader.load();
 
             TemplateFormController templateFormController = loader.getController();
-            templateFormController.setFormSubmitListener(test -> {
-                handleSubmittedNewTemplate(test);
+            templateFormController.setFormSubmitListener(newTemplate -> {
+                addSubmittedTemplateToPreset(newTemplate);
             }
             );
 
@@ -159,7 +159,7 @@ public class MainController {
         return new ImageTemplate(null, 600, 400, null, null, null, null, "jpg");
     }
 
-    private void handleSubmittedNewTemplate(String test) {
-        System.out.println("submitted template : "+test);
+    private void addSubmittedTemplateToPreset(ImageTemplate template) {
+        System.out.println("submitted template : "+template.getTemplateName());
     }
 }

--- a/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
@@ -5,14 +5,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
-import com.gregorybroche.imageresolver.classes.Preset;
 import com.gregorybroche.imageresolver.classes.ImageTemplate;
 import com.gregorybroche.imageresolver.service.FileHandlerService;
 import com.gregorybroche.imageresolver.service.ImageEditorService;
@@ -21,6 +18,7 @@ import com.gregorybroche.imageresolver.service.ResolverProcessorService;
 import com.gregorybroche.imageresolver.service.UserDialogService;
 import com.gregorybroche.imageresolver.service.ValidatorService;
 
+import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
@@ -29,7 +27,7 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
@@ -85,7 +83,7 @@ public class MainController {
     }
 
     @FXML
-    void selectImage(MouseEvent event) {
+    void selectImage() {
         try {
             File selectedFile = userDialogService.selectImageFile();
             if (!validatorService.isFileValidImageFormat(selectedFile)) {
@@ -102,7 +100,7 @@ public class MainController {
     }
 
     @FXML
-    void resolveImage(MouseEvent event) {
+    void resolveImage() {
         try {
             BufferedImage sourceBufferedImage = imageEditorService.getImageContentFromFile(imageToResolve);
             ImageTemplate template = getTemplateParameters();
@@ -115,7 +113,7 @@ public class MainController {
     }
 
     @FXML
-    void openTemplateForm(MouseEvent event) {
+    void openTemplateForm(ActionEvent event) {
         try {
             FXMLLoader loader = new FXMLLoader(getClass().getResource("../views/templateForm.fxml"));
             loader.setControllerFactory(applicationContext::getBean);
@@ -174,10 +172,24 @@ public class MainController {
         return new ImageTemplate("testTemplate", 600, 400, 96, null, "testImage", null, "jpg");
     }
 
+    /**
+     * adds a template to currently managed preset and refresh the template list display
+     * @param template display to add
+     */
     private void addSubmittedTemplateToPreset(ImageTemplate template) {
-        System.out.println("submitted template : "+template.getTemplateName());
         presetManagementService.addTemplateToPreset(template, Selectedpreset);
-        System.out.println("template was added; preset '"+presetManagementService.getPresetFromKey(Selectedpreset).getName()+
-        "' -> template '"+presetManagementService.getPresetFromKey(Selectedpreset).getTemplates().get(0).getTemplateName()+"'");
+        displayLoadedTemplates();
+    }
+
+    /**
+     * display templates belonging to the current preset in the dedicated component list
+     */
+    private void displayLoadedTemplates(){
+        List<ImageTemplate> templates = presetManagementService.getPresetFromKey(Selectedpreset).getTemplates();
+        List<HBox> templateComponents = new ArrayList<HBox>();
+        for (int i = 0; i < templates.size(); i++) {
+            templateComponents.add(templates.get(i).createTemplateComponent(i)) ;
+        }
+        templateContainer.getChildren().setAll(templateComponents);
     }
 }

--- a/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
@@ -106,6 +106,12 @@ public class MainController {
             loader.setControllerFactory(applicationContext::getBean);
             Parent root = loader.load();
 
+            TemplateFormController templateFormController = loader.getController();
+            templateFormController.setFormSubmitListener(test -> {
+                handleSubmittedNewTemplate(test);
+            }
+            );
+
             Stage stage = new Stage();
             stage.setTitle("Template Form");
 
@@ -153,4 +159,7 @@ public class MainController {
         return new ImageTemplate(null, 600, 400, null, null, null, null, "jpg");
     }
 
+    private void handleSubmittedNewTemplate(String test) {
+        System.out.println("submitted template : "+test);
+    }
 }

--- a/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
@@ -177,7 +177,7 @@ public class MainController {
     private void addSubmittedTemplateToPreset(ImageTemplate template) {
         System.out.println("submitted template : "+template.getTemplateName());
         presetManagementService.addTemplateToPreset(template, Selectedpreset);
-        System.out.println("template was added; preset '"+presetManagementService.getPresetByKey(Selectedpreset).getName()+
-        "' -> template '"+presetManagementService.getPresetByKey(Selectedpreset).getTemplates().get(0).getTemplateName()+"'");
+        System.out.println("template was added; preset '"+presetManagementService.getPresetFromKey(Selectedpreset).getName()+
+        "' -> template '"+presetManagementService.getPresetFromKey(Selectedpreset).getTemplates().get(0).getTemplateName()+"'");
     }
 }

--- a/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
@@ -15,11 +15,17 @@ import com.gregorybroche.imageresolver.service.UserDialogService;
 import com.gregorybroche.imageresolver.service.ValidatorService;
 
 import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.VBox;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
 
 @Component
 public class MainController {
@@ -30,18 +36,18 @@ public class MainController {
     private ResolverProcessorService resolverProcessorService;
     private File imageToResolve = null;
 
-    public MainController(  UserDialogService userDialogService,
-                            FileHandlerService fileHandlerService,
-                            ValidatorService validatorService,
-                            ImageEditorService imageEditorService,
-                            ResolverProcessorService resolverProcessorService) {
+    public MainController(UserDialogService userDialogService,
+            FileHandlerService fileHandlerService,
+            ValidatorService validatorService,
+            ImageEditorService imageEditorService,
+            ResolverProcessorService resolverProcessorService) {
         this.userDialogService = userDialogService;
         this.fileHandlerService = fileHandlerService;
         this.validatorService = validatorService;
         this.imageEditorService = imageEditorService;
         this.resolverProcessorService = resolverProcessorService;
-    } 
-    
+    }
+
     @FXML
     private ImageView imagePreview;
 
@@ -76,10 +82,11 @@ public class MainController {
 
     @FXML
     void resolveImage(MouseEvent event) {
-        try{
+        try {
             BufferedImage sourceBufferedImage = imageEditorService.getImageContentFromFile(imageToResolve);
             ImageTemplate template = getTemplateParameters();
-            Path directory = fileHandlerService.getAppDirectoryPath(); //Temporary for testing until logic for defining templates and presets through inputs is done
+            Path directory = fileHandlerService.getAppDirectoryPath(); // Temporary for testing until logic for defining
+                                                                       // templates and presets through inputs is done
             resolverProcessorService.processImageForTemplate(sourceBufferedImage, template, directory);
         } catch (Exception e) {
             userDialogService.showErrorMessage("failed to resolve image", e.getMessage());
@@ -87,29 +94,35 @@ public class MainController {
     }
 
     @FXML
-    /**
-     * Implementation as proof of concept of creating an ImageTemplate instance and displaying the
-     * corresponding data into an appended fxml component
-     * @param event
-     */
-    void createTemplate(MouseEvent event){
-        System.out.println("***CREATING TEMPLATE VIEW***");
-        System.out.println(templateContainer);
-        // Create a new ImageTemplate instance
-        ImageTemplate newTemplate = new ImageTemplate(null, 600, 400, null, null, null, null, "jpg");
-        System.out.println("***CREATING IMAGE TEMPLATE INSTANCE***");
+    void openTemplateForm(MouseEvent event) {
+        try {
+            FXMLLoader loader = new FXMLLoader(getClass().getResource("../views/templateForm.fxml"));
+            Parent root = loader.load();
 
-        // Create the template pane (an HBox) using the FXML and add it to the VBox
-        templateContainer.getChildren().add(newTemplate.createTemplatePane(0));
-        System.out.println("***DISPLAY TEMPLATE***");
+            Stage stage = new Stage();
+            stage.setTitle("Template Form");
+
+            Scene scene = new Scene(root);
+            stage.setScene(scene);
+
+            stage.initModality(Modality.WINDOW_MODAL);
+
+            stage.initOwner(((Node) event.getSource()).getScene().getWindow());
+
+            stage.showAndWait();
+
+        } catch (Exception e) {
+            System.err.println(e.getMessage());
+        }
     }
 
     /**
      * Return an Image object generated based on a given file path
+     * 
      * @param filePath instance of Path corresponding to the target file
      * @return Image object generated
      */
-    private Image getImageFromFilePath(Path filePath){
+    private Image getImageFromFilePath(Path filePath) {
         try {
             FileInputStream inputStream = new FileInputStream(filePath.toFile());
             Image image = new Image(inputStream);
@@ -123,12 +136,13 @@ public class MainController {
     /**
      * Display preview of currently selected image
      */
-    private void displaySelectedImagePreview(Image image){
+    private void displaySelectedImagePreview(Image image) {
         imagePreview.setImage(image);
     }
 
-    // Proof of concept testing until proper definition of templates through user inputs
-    private ImageTemplate getTemplateParameters(){
+    // Proof of concept testing until proper definition of templates through user
+    // inputs
+    private ImageTemplate getTemplateParameters() {
         return new ImageTemplate(null, 600, 400, null, null, null, null, "jpg");
     }
 

--- a/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.nio.file.Path;
 
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 import com.gregorybroche.imageresolver.classes.ImageTemplate;
@@ -29,6 +30,7 @@ import javafx.stage.Stage;
 
 @Component
 public class MainController {
+    private ApplicationContext applicationContext;
     private UserDialogService userDialogService;
     private FileHandlerService fileHandlerService;
     private ValidatorService validatorService;
@@ -36,11 +38,15 @@ public class MainController {
     private ResolverProcessorService resolverProcessorService;
     private File imageToResolve = null;
 
-    public MainController(UserDialogService userDialogService,
+    public MainController(
+            ApplicationContext applicationContext,
+            UserDialogService userDialogService,
             FileHandlerService fileHandlerService,
             ValidatorService validatorService,
             ImageEditorService imageEditorService,
-            ResolverProcessorService resolverProcessorService) {
+            ResolverProcessorService resolverProcessorService
+            ) {
+        this.applicationContext = applicationContext;
         this.userDialogService = userDialogService;
         this.fileHandlerService = fileHandlerService;
         this.validatorService = validatorService;
@@ -97,6 +103,7 @@ public class MainController {
     void openTemplateForm(MouseEvent event) {
         try {
             FXMLLoader loader = new FXMLLoader(getClass().getResource("../views/templateForm.fxml"));
+            loader.setControllerFactory(applicationContext::getBean);
             Parent root = loader.load();
 
             Stage stage = new Stage();

--- a/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
@@ -96,7 +96,7 @@ public class MainController {
         System.out.println("***CREATING TEMPLATE VIEW***");
         System.out.println(templateContainer);
         // Create a new ImageTemplate instance
-        ImageTemplate newTemplate = new ImageTemplate();
+        ImageTemplate newTemplate = new ImageTemplate(null, 600, 400, null, null, null, null, "jpg");
         System.out.println("***CREATING IMAGE TEMPLATE INSTANCE***");
 
         // Create the template pane (an HBox) using the FXML and add it to the VBox
@@ -129,7 +129,7 @@ public class MainController {
 
     // Proof of concept testing until proper definition of templates through user inputs
     private ImageTemplate getTemplateParameters(){
-        return new ImageTemplate();
+        return new ImageTemplate(null, 600, 400, null, null, null, null, "jpg");
     }
 
 }

--- a/src/main/java/com/gregorybroche/imageresolver/controller/TemplateItemController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/TemplateItemController.java
@@ -12,10 +12,11 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.cell.PropertyValueFactory;
-import javafx.scene.input.MouseEvent;
 
 @Component
 public class TemplateItemController {
+    private int indexInTemplateList;
+
     @FXML
     private Label templateName;
 
@@ -59,23 +60,26 @@ public class TemplateItemController {
     @FXML
     /**
      * placeholder for editing this template
-     * @param event
      */
-    void editTemplate(MouseEvent event) {
-        System.out.println("implement edit window action");
+    void editTemplate() {
+        System.out.println("implement edit window action on "+indexInTemplateList);
     }
 
     @FXML
     /**
      * placeholder for deleting this template
-     * @param event
      */
-    void deleteTemplate(MouseEvent event) {
-        System.out.println("implement delete action");
+    void deleteTemplate() {
+        System.out.println("implement delete action on "+indexInTemplateList);
     }
 
-    // Method to set the data in the HBox
-    public void setTemplateData(ImageTemplate imageTemplate, Integer indexInPreset) {
+    /**
+     * sets this template data using a template instance and an index
+     * @param imageTemplate
+     * @param indexInPreset index of the template inside a preset's template list
+     */
+    public void setTemplateData(ImageTemplate imageTemplate, int indexInPreset) {
+        indexInTemplateList = indexInPreset;
         setLabels(imageTemplate);
         setFileNamingConvention(imageTemplate);
         setSizeInfo(imageTemplate);

--- a/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
@@ -1,10 +1,9 @@
 package com.gregorybroche.imageresolver.controller;
 
-import java.awt.event.ActionEvent;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.gregorybroche.imageresolver.classes.ValidationResponse;
 import com.gregorybroche.imageresolver.service.TemplateFormValidatorService;
 import com.gregorybroche.imageresolver.service.ValidatorService;
 
@@ -13,7 +12,6 @@ import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.TextField;
-import javafx.scene.input.KeyEvent;
 import javafx.scene.text.Text;
 
 @Component
@@ -22,10 +20,12 @@ public class TemplateFormController {
 
     @Autowired
     private TemplateFormValidatorService templateFormValidatorService;
+
+    @Autowired
+    private ValidatorService validatorService;
     
     public void setFormSubmitListener(TemplateFormSubmitListener listener) {
         this.submitListener = listener;
-
     }
     public interface TemplateFormSubmitListener {
         void onFormSubmit();
@@ -98,8 +98,13 @@ public class TemplateFormController {
 
     @FXML
     void validateTemplateNameChange() {
-        String templateName = inputTemplateName.getText();
-        System.out.println(templateName);
+        String input = validatorService.sanitizeString(inputTemplateName.getText());
+        ValidationResponse validationState = templateFormValidatorService.validateTemplateNameInput(input);
+        if(!validationState.getIsSuccess()){
+            showInputError(inputTemplateNameError, validationState.getMessage());
+            return;
+        }
+        hideInputError(inputTemplateNameError);
     }
 
     @FXML
@@ -128,5 +133,15 @@ public class TemplateFormController {
 
     @FXML
     void validateFormatChange() {
+    }
+
+    
+    public void showInputError(Text textElement, String text){
+        textElement.setText(text);
+        textElement.setVisible(true);
+    }
+    public void hideInputError(Text textElement){
+        textElement.setVisible(false);
+        textElement.setText("");
     }
 }

--- a/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
@@ -17,6 +17,7 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.TextField;
 import javafx.scene.text.Text;
+import javafx.stage.Stage;
 
 @Component
 public class TemplateFormController {
@@ -97,8 +98,9 @@ public class TemplateFormController {
     @FXML
     public void initialize() {
         initializeInputValidationMap();
-        selectFormat.getItems().addAll("png", "jpg", "bmp", "gif");
-        selectFormat.setValue("png");
+        String[] allowedOutputFormats = templateFormValidatorService.getAllowedFormats();
+        selectFormat.getItems().addAll(allowedOutputFormats);
+        selectFormat.setValue(allowedOutputFormats[0]);
     }
 
     @FXML
@@ -235,10 +237,22 @@ public class TemplateFormController {
                 format);
 
             this.submitListener.onFormSubmit(templateToAdd);
+            closeModal();
+            
         } catch (Exception e) {
             System.err.println("handle submit - catch");
             System.err.println(e.getMessage());
         }
+    }
+
+    @FXML
+    private void cancelForm(){
+        closeModal();
+    }
+
+    private void closeModal(){
+        Stage modalStage = (Stage) buttonSave.getScene().getWindow();
+        modalStage.close();
     }
 
     public void showInputError(Text textElement, String text) {

--- a/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
@@ -27,14 +27,15 @@ public class TemplateFormController {
 
     @Autowired
     private ValidatorService validatorService;
-    
+
     public void setFormSubmitListener(TemplateFormSubmitListener listener) {
         this.submitListener = listener;
     }
+
     public interface TemplateFormSubmitListener {
         void onFormSubmit();
     }
-    
+
     @FXML
     TextField inputTemplateName;
 
@@ -49,13 +50,13 @@ public class TemplateFormController {
 
     @FXML
     TextField inputFilePrefix;
-    
+
     @FXML
     Text inputFilePrefixError;
 
     @FXML
     TextField inputFileSuffix;
-    
+
     @FXML
     Text inputFileSuffixError;
 
@@ -64,25 +65,25 @@ public class TemplateFormController {
 
     @FXML
     TextField inputWidth;
-    
+
     @FXML
     Text inputWidthError;
 
     @FXML
     TextField inputHeight;
-    
+
     @FXML
     Text inputHeightError;
 
     @FXML
     TextField inputResolution;
-    
+
     @FXML
     Text inputResolutionError;
 
     @FXML
     ChoiceBox<String> selectFormat;
-    
+
     @FXML
     Text selectFormatError;
 
@@ -94,20 +95,18 @@ public class TemplateFormController {
 
     @FXML
     public void initialize() {
-    // Populate ChoiceBox with some items
-    selectFormat.getItems().addAll("PNG", "JPG", "BMP", "GIF");
-    selectFormat.setValue("PNG"); // Set default value if needed
-    initializeInputValidationMap();
-}
-
+        initializeInputValidationMap();
+        selectFormat.getItems().addAll("png", "jpg", "bmp", "gif");
+        selectFormat.setValue("png");
+    }
 
     @FXML
     void validateTemplateNameChange() {
         String input = validatorService.sanitizeString(inputTemplateName.getText());
         ValidationResponse validationState = templateFormValidatorService.validateTemplateNameInput(input);
-        if(!validationState.getIsSuccess()){
+        if (!validationState.getIsSuccess()) {
             showInputError(inputTemplateNameError, validationState.getMessage());
-        }else{
+        } else {
             hideInputError(inputTemplateNameError);
         }
         setInputValidationForTemplateName(validationState.getIsSuccess());
@@ -116,43 +115,107 @@ public class TemplateFormController {
 
     @FXML
     void validateImageBaseNameChange() {
+        String input = validatorService.sanitizeString(inputFileBaseName.getText());
+        ValidationResponse validationState = templateFormValidatorService.validateBaseNameInput(input);
+        if (!validationState.getIsSuccess()) {
+            showInputError(inputFileBaseNameError, validationState.getMessage());
+        } else {
+            hideInputError(inputFileBaseNameError);
+        }
+        setInputValidationForBaseName(validationState.getIsSuccess());
+        toggleSaveButton(areInputsValid());
     }
 
     @FXML
     void validateImagePrefixChange() {
+        String input = validatorService.sanitizeString(inputFilePrefix.getText());
+        ValidationResponse validationState = templateFormValidatorService.validatePrefixInput(input);
+        if (!validationState.getIsSuccess()) {
+            showInputError(inputFilePrefixError, validationState.getMessage());
+        } else {
+            hideInputError(inputFilePrefixError);
+        }
+        setInputValidationForPrefix(validationState.getIsSuccess());
+        toggleSaveButton(areInputsValid());
     }
 
     @FXML
     void validateImageSuffixChange() {
+        String input = validatorService.sanitizeString(inputFileSuffix.getText());
+        ValidationResponse validationState = templateFormValidatorService.validateSuffixInput(input);
+        if (!validationState.getIsSuccess()) {
+            showInputError(inputFileSuffixError, validationState.getMessage());
+        } else {
+            hideInputError(inputFileSuffixError);
+        }
+        setInputValidationForSuffix(validationState.getIsSuccess());
+        toggleSaveButton(areInputsValid());
     }
 
     @FXML
     void validateWidthChange() {
+        Integer input = validatorService.sanitizeStringAsInteger(inputWidth.getText());
+        ValidationResponse validationState = templateFormValidatorService.validateWidthInput(input);
+        if (!validationState.getIsSuccess()) {
+            showInputError(inputWidthError, validationState.getMessage());
+        } else {
+            hideInputError(inputWidthError);
+        }
+        setInputValidationForWidth(validationState.getIsSuccess());
+        toggleSaveButton(areInputsValid());
     }
 
     @FXML
     void validateHeightChange() {
+        Integer input = validatorService.sanitizeStringAsInteger(inputHeight.getText());
+        ValidationResponse validationState = templateFormValidatorService.validateHeightInput(input);
+        if (!validationState.getIsSuccess()) {
+            showInputError(inputHeightError, validationState.getMessage());
+        } else {
+            hideInputError(inputHeightError);
+        }
+        setInputValidationForHeight(validationState.getIsSuccess());
+        toggleSaveButton(areInputsValid());
     }
 
     @FXML
     void validateResolutionChange() {
+        Integer input = validatorService.sanitizeStringAsInteger(inputResolution.getText());
+        ValidationResponse validationState = templateFormValidatorService.validateResolutionInput(input);
+        if (!validationState.getIsSuccess()) {
+            showInputError(inputResolutionError, validationState.getMessage());
+        } else {
+            hideInputError(inputResolutionError);
+        }
+        setInputValidationForResolution(validationState.getIsSuccess());
+        toggleSaveButton(areInputsValid());
     }
 
     @FXML
     void validateFormatChange() {
+        String input = validatorService.sanitizeString(selectFormat.getValue());
+        System.out.println(input);
+        ValidationResponse validationState = templateFormValidatorService.validateFormatInput(input);
+        if (!validationState.getIsSuccess()) {
+            showInputError(selectFormatError, validationState.getMessage());
+        } else {
+            hideInputError(selectFormatError);
+        }
+        setInputValidationForFormat(validationState.getIsSuccess());
+        toggleSaveButton(areInputsValid());
     }
 
-    
-    public void showInputError(Text textElement, String text){
+    public void showInputError(Text textElement, String text) {
         textElement.setText(text);
         textElement.setVisible(true);
     }
-    public void hideInputError(Text textElement){
+
+    public void hideInputError(Text textElement) {
         textElement.setVisible(false);
         textElement.setText("");
     }
 
-    public void initializeInputValidationMap(){
+    public void initializeInputValidationMap() {
         setInputValidationForTemplateName(false);
         setInputValidationForBaseName(false);
         setInputValidationForPrefix(false);
@@ -163,45 +226,51 @@ public class TemplateFormController {
         setInputValidationForFormat(false);
     }
 
-    public void toggleSaveButton(boolean mustEnableButton){
+    public void toggleSaveButton(boolean mustEnableButton) {
         buttonSave.setDisable(!mustEnableButton);
     }
 
-    public boolean areInputsValid(){
-        return (
-            inputValidationMap.get("templateName")
-            // && inputValidationMap.get("baseName")
-            // && inputValidationMap.get("prefix")
-            // && inputValidationMap.get("suffix")
-            // && inputValidationMap.get("width")
-            // && inputValidationMap.get("height")
-            // && inputValidationMap.get("resolution")
-            // && inputValidationMap.get("format")
+    public boolean areInputsValid() {
+        return (inputValidationMap.get("templateName")
+        && inputValidationMap.get("baseName")
+        && inputValidationMap.get("prefix")
+        && inputValidationMap.get("suffix")
+        && inputValidationMap.get("width")
+        && inputValidationMap.get("height")
+        && inputValidationMap.get("resolution")
+        && inputValidationMap.get("format")
         );
     }
 
-    public void setInputValidationForTemplateName(boolean isInputValid){
+    public void setInputValidationForTemplateName(boolean isInputValid) {
         inputValidationMap.put("templateName", isInputValid);
     }
-    public void setInputValidationForBaseName(boolean isInputValid){
+
+    public void setInputValidationForBaseName(boolean isInputValid) {
         inputValidationMap.put("baseName", isInputValid);
     }
-    public void setInputValidationForPrefix(boolean isInputValid){
+
+    public void setInputValidationForPrefix(boolean isInputValid) {
         inputValidationMap.put("prefix", isInputValid);
     }
-    public void setInputValidationForSuffix(boolean isInputValid){
+
+    public void setInputValidationForSuffix(boolean isInputValid) {
         inputValidationMap.put("suffix", isInputValid);
     }
-    public void setInputValidationForWidth(boolean isInputValid){
+
+    public void setInputValidationForWidth(boolean isInputValid) {
         inputValidationMap.put("width", isInputValid);
     }
-    public void setInputValidationForHeight(boolean isInputValid){
+
+    public void setInputValidationForHeight(boolean isInputValid) {
         inputValidationMap.put("height", isInputValid);
     }
-    public void setInputValidationForResolution(boolean isInputValid){
+
+    public void setInputValidationForResolution(boolean isInputValid) {
         inputValidationMap.put("resolution", isInputValid);
     }
-    public void setInputValidationForFormat(boolean isInputValid){
+
+    public void setInputValidationForFormat(boolean isInputValid) {
         inputValidationMap.put("format", isInputValid);
     }
 }

--- a/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.gregorybroche.imageresolver.classes.ImageTemplate;
 import com.gregorybroche.imageresolver.classes.ValidationResponse;
 import com.gregorybroche.imageresolver.service.TemplateFormValidatorService;
 import com.gregorybroche.imageresolver.service.ValidatorService;
@@ -33,7 +34,7 @@ public class TemplateFormController {
     }
 
     public interface TemplateFormSubmitListener {
-        void onFormSubmit();
+        void onFormSubmit(ImageTemplate submittedTemplate);
     }
 
     @FXML
@@ -154,7 +155,7 @@ public class TemplateFormController {
 
     @FXML
     void validateWidthChange() {
-        Integer input = validatorService.sanitizeStringAsInteger(inputWidth.getText());
+        String input = validatorService.sanitizeString(inputWidth.getText());
         ValidationResponse validationState = templateFormValidatorService.validateWidthInput(input);
         if (!validationState.getIsSuccess()) {
             showInputError(inputWidthError, validationState.getMessage());
@@ -167,7 +168,7 @@ public class TemplateFormController {
 
     @FXML
     void validateHeightChange() {
-        Integer input = validatorService.sanitizeStringAsInteger(inputHeight.getText());
+        String input = validatorService.sanitizeString(inputHeight.getText());
         ValidationResponse validationState = templateFormValidatorService.validateHeightInput(input);
         if (!validationState.getIsSuccess()) {
             showInputError(inputHeightError, validationState.getMessage());
@@ -180,7 +181,7 @@ public class TemplateFormController {
 
     @FXML
     void validateResolutionChange() {
-        Integer input = validatorService.sanitizeStringAsInteger(inputResolution.getText());
+        String input = validatorService.sanitizeString(inputResolution.getText());
         ValidationResponse validationState = templateFormValidatorService.validateResolutionInput(input);
         if (!validationState.getIsSuccess()) {
             showInputError(inputResolutionError, validationState.getMessage());

--- a/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
@@ -1,54 +1,132 @@
 package com.gregorybroche.imageresolver.controller;
 
+import java.awt.event.ActionEvent;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import com.gregorybroche.imageresolver.service.TemplateFormValidatorService;
+import com.gregorybroche.imageresolver.service.ValidatorService;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.text.Text;
 
 @Component
-public class templateFormController {
+public class TemplateFormController {
     private TemplateFormSubmitListener submitListener;
 
+    @Autowired
+    private TemplateFormValidatorService templateFormValidatorService;
+    
     public void setFormSubmitListener(TemplateFormSubmitListener listener) {
         this.submitListener = listener;
+
     }
     public interface TemplateFormSubmitListener {
-        void onFormSubmit(String name, String email);
+        void onFormSubmit();
     }
     
     @FXML
-    TextField InputTemplateName;
+    TextField inputTemplateName;
 
     @FXML
-    TextField InputFileBaseName;
+    Text inputTemplateNameError;
 
     @FXML
-    TextField InputFilePrefix;
+    TextField inputFileBaseName;
 
     @FXML
-    TextField InputFileSuffix;
+    Text inputFileBaseNameError;
 
     @FXML
-    CheckBox CheckboxMaintainRatio;
+    TextField inputFilePrefix;
+    
+    @FXML
+    Text inputFilePrefixError;
+
+    @FXML
+    TextField inputFileSuffix;
+    
+    @FXML
+    Text inputFileSuffixError;
+
+    @FXML
+    CheckBox checkboxMaintainRatio;
 
     @FXML
     TextField inputWidth;
+    
+    @FXML
+    Text inputWidthError;
 
     @FXML
     TextField inputHeight;
+    
+    @FXML
+    Text inputHeightError;
 
     @FXML
     TextField inputResolution;
+    
+    @FXML
+    Text inputResolutionError;
 
     @FXML
-    ChoiceBox selectFormat;
+    ChoiceBox<String> selectFormat;
+    
+    @FXML
+    Text selectFormatError;
 
     @FXML
     Button buttonCancel;
 
     @FXML
     Button buttonSave;
+
+    @FXML
+    public void initialize() {
+    // Populate ChoiceBox with some items
+    selectFormat.getItems().addAll("PNG", "JPG", "BMP", "GIF");
+    selectFormat.setValue("PNG"); // Set default value if needed
+}
+
+
+    @FXML
+    void validateTemplateNameChange() {
+        String templateName = inputTemplateName.getText();
+        System.out.println(templateName);
+    }
+
+    @FXML
+    void validateImageBaseNameChange() {
+    }
+
+    @FXML
+    void validateImagePrefixChange() {
+    }
+
+    @FXML
+    void validateImageSuffixChange() {
+    }
+
+    @FXML
+    void validateWidthChange() {
+    }
+
+    @FXML
+    void validateHeightChange() {
+    }
+
+    @FXML
+    void validateResolutionChange() {
+    }
+
+    @FXML
+    void validateFormatChange() {
+    }
 }

--- a/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
@@ -1,0 +1,54 @@
+package com.gregorybroche.imageresolver.controller;
+
+import org.springframework.stereotype.Component;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.TextField;
+
+@Component
+public class templateFormController {
+    private TemplateFormSubmitListener submitListener;
+
+    public void setFormSubmitListener(TemplateFormSubmitListener listener) {
+        this.submitListener = listener;
+    }
+    public interface TemplateFormSubmitListener {
+        void onFormSubmit(String name, String email);
+    }
+    
+    @FXML
+    TextField InputTemplateName;
+
+    @FXML
+    TextField InputFileBaseName;
+
+    @FXML
+    TextField InputFilePrefix;
+
+    @FXML
+    TextField InputFileSuffix;
+
+    @FXML
+    CheckBox CheckboxMaintainRatio;
+
+    @FXML
+    TextField inputWidth;
+
+    @FXML
+    TextField inputHeight;
+
+    @FXML
+    TextField inputResolution;
+
+    @FXML
+    ChoiceBox selectFormat;
+
+    @FXML
+    Button buttonCancel;
+
+    @FXML
+    Button buttonSave;
+}

--- a/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
@@ -34,7 +34,7 @@ public class TemplateFormController {
     }
 
     public interface TemplateFormSubmitListener {
-        void onFormSubmit(ImageTemplate submittedTemplate);
+        void onFormSubmit(String submittedTemplate);
     }
 
     @FXML
@@ -102,7 +102,7 @@ public class TemplateFormController {
     }
 
     @FXML
-    void validateTemplateNameChange() {
+    private void validateTemplateNameChange() {
         String input = validatorService.sanitizeString(inputTemplateName.getText());
         ValidationResponse validationState = templateFormValidatorService.validateTemplateNameInput(input);
         if (!validationState.getIsSuccess()) {
@@ -115,7 +115,7 @@ public class TemplateFormController {
     }
 
     @FXML
-    void validateImageBaseNameChange() {
+    private void validateImageBaseNameChange() {
         String input = validatorService.sanitizeString(inputFileBaseName.getText());
         ValidationResponse validationState = templateFormValidatorService.validateBaseNameInput(input);
         if (!validationState.getIsSuccess()) {
@@ -128,7 +128,7 @@ public class TemplateFormController {
     }
 
     @FXML
-    void validateImagePrefixChange() {
+    private void validateImagePrefixChange() {
         String input = validatorService.sanitizeString(inputFilePrefix.getText());
         ValidationResponse validationState = templateFormValidatorService.validatePrefixInput(input);
         if (!validationState.getIsSuccess()) {
@@ -141,7 +141,7 @@ public class TemplateFormController {
     }
 
     @FXML
-    void validateImageSuffixChange() {
+    private void validateImageSuffixChange() {
         String input = validatorService.sanitizeString(inputFileSuffix.getText());
         ValidationResponse validationState = templateFormValidatorService.validateSuffixInput(input);
         if (!validationState.getIsSuccess()) {
@@ -154,7 +154,7 @@ public class TemplateFormController {
     }
 
     @FXML
-    void validateWidthChange() {
+    private void validateWidthChange() {
         String input = validatorService.sanitizeString(inputWidth.getText());
         ValidationResponse validationState = templateFormValidatorService.validateWidthInput(input);
         if (!validationState.getIsSuccess()) {
@@ -167,7 +167,7 @@ public class TemplateFormController {
     }
 
     @FXML
-    void validateHeightChange() {
+    private void validateHeightChange() {
         String input = validatorService.sanitizeString(inputHeight.getText());
         ValidationResponse validationState = templateFormValidatorService.validateHeightInput(input);
         if (!validationState.getIsSuccess()) {
@@ -180,7 +180,7 @@ public class TemplateFormController {
     }
 
     @FXML
-    void validateResolutionChange() {
+    private void validateResolutionChange() {
         String input = validatorService.sanitizeString(inputResolution.getText());
         ValidationResponse validationState = templateFormValidatorService.validateResolutionInput(input);
         if (!validationState.getIsSuccess()) {
@@ -193,7 +193,7 @@ public class TemplateFormController {
     }
 
     @FXML
-    void validateFormatChange() {
+    private void validateFormatChange() {
         String input = validatorService.sanitizeString(selectFormat.getValue());
         System.out.println(input);
         ValidationResponse validationState = templateFormValidatorService.validateFormatInput(input);
@@ -204,6 +204,33 @@ public class TemplateFormController {
         }
         setInputValidationForFormat(validationState.getIsSuccess());
         toggleSaveButton(areInputsValid());
+    }
+
+    @FXML
+    private void handleSubmit() {
+        if(!areInputsValid()){
+            return;
+        }
+        if(this.submitListener == null){
+            System.err.println("listener not set");
+            return;
+        }
+        try {
+            String templateName = validatorService.sanitizeString(inputTemplateName.getText());
+            // ImageTemplate templateToAdd = new ImageTemplate(
+            //     null,
+            //     0,
+            //     0,
+            //     null,
+            //     null,
+            //     null,
+            //     null,
+            //     null);
+            this.submitListener.onFormSubmit(templateName);
+        } catch (Exception e) {
+            System.err.println("handle submit - catch");
+            System.err.println(e.getMessage());
+        }
     }
 
     public void showInputError(Text textElement, String text) {
@@ -217,14 +244,14 @@ public class TemplateFormController {
     }
 
     public void initializeInputValidationMap() {
-        setInputValidationForTemplateName(false);
-        setInputValidationForBaseName(false);
-        setInputValidationForPrefix(false);
-        setInputValidationForSuffix(false);
-        setInputValidationForWidth(false);
-        setInputValidationForHeight(false);
-        setInputValidationForResolution(false);
-        setInputValidationForFormat(false);
+        setInputValidationForTemplateName(!templateFormValidatorService.isTemplateNameRequired());
+        setInputValidationForBaseName(!templateFormValidatorService.isImageBaseNameRequired());
+        setInputValidationForPrefix(!templateFormValidatorService.isImagePrefixRequired());
+        setInputValidationForSuffix(!templateFormValidatorService.isImageSuffixRequired());
+        setInputValidationForWidth(!templateFormValidatorService.isWidthRequired());
+        setInputValidationForHeight(!templateFormValidatorService.isHeightRequired());
+        setInputValidationForResolution(!templateFormValidatorService.isResolutionRequired());
+        setInputValidationForFormat(!templateFormValidatorService.isFormatRequired());
     }
 
     public void toggleSaveButton(boolean mustEnableButton) {

--- a/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
@@ -34,7 +34,7 @@ public class TemplateFormController {
     }
 
     public interface TemplateFormSubmitListener {
-        void onFormSubmit(String submittedTemplate);
+        void onFormSubmit(ImageTemplate imageTemplate);
     }
 
     @FXML
@@ -195,7 +195,6 @@ public class TemplateFormController {
     @FXML
     private void validateFormatChange() {
         String input = validatorService.sanitizeString(selectFormat.getValue());
-        System.out.println(input);
         ValidationResponse validationState = templateFormValidatorService.validateFormatInput(input);
         if (!validationState.getIsSuccess()) {
             showInputError(selectFormatError, validationState.getMessage());
@@ -217,16 +216,25 @@ public class TemplateFormController {
         }
         try {
             String templateName = validatorService.sanitizeString(inputTemplateName.getText());
-            // ImageTemplate templateToAdd = new ImageTemplate(
-            //     null,
-            //     0,
-            //     0,
-            //     null,
-            //     null,
-            //     null,
-            //     null,
-            //     null);
-            this.submitListener.onFormSubmit(templateName);
+            String baseName = validatorService.sanitizeString(inputFileBaseName.getText());
+            String prefix = validatorService.sanitizeString(inputFilePrefix.getText());
+            String suffix = validatorService.sanitizeString(inputFileSuffix.getText());
+            int width = validatorService.sanitizeStringAsInteger(inputWidth.getText());
+            int height = validatorService.sanitizeStringAsInteger(inputHeight.getText());
+            int resolution = validatorService.sanitizeStringAsInteger(inputResolution.getText());
+            String format = validatorService.sanitizeString(selectFormat.getValue());
+
+            ImageTemplate templateToAdd = new ImageTemplate(
+                templateName,
+                width,
+                height,
+                resolution,
+                prefix,
+                baseName,
+                suffix,
+                format);
+
+            this.submitListener.onFormSubmit(templateToAdd);
         } catch (Exception e) {
             System.err.println("handle submit - catch");
             System.err.println(e.getMessage());

--- a/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
@@ -1,5 +1,8 @@
 package com.gregorybroche.imageresolver.controller;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -17,6 +20,7 @@ import javafx.scene.text.Text;
 @Component
 public class TemplateFormController {
     private TemplateFormSubmitListener submitListener;
+    private Map<String, Boolean> inputValidationMap = new HashMap<String, Boolean>();
 
     @Autowired
     private TemplateFormValidatorService templateFormValidatorService;
@@ -93,6 +97,7 @@ public class TemplateFormController {
     // Populate ChoiceBox with some items
     selectFormat.getItems().addAll("PNG", "JPG", "BMP", "GIF");
     selectFormat.setValue("PNG"); // Set default value if needed
+    initializeInputValidationMap();
 }
 
 
@@ -102,9 +107,11 @@ public class TemplateFormController {
         ValidationResponse validationState = templateFormValidatorService.validateTemplateNameInput(input);
         if(!validationState.getIsSuccess()){
             showInputError(inputTemplateNameError, validationState.getMessage());
-            return;
+        }else{
+            hideInputError(inputTemplateNameError);
         }
-        hideInputError(inputTemplateNameError);
+        setInputValidationForTemplateName(validationState.getIsSuccess());
+        toggleSaveButton(areInputsValid());
     }
 
     @FXML
@@ -143,5 +150,58 @@ public class TemplateFormController {
     public void hideInputError(Text textElement){
         textElement.setVisible(false);
         textElement.setText("");
+    }
+
+    public void initializeInputValidationMap(){
+        setInputValidationForTemplateName(false);
+        setInputValidationForBaseName(false);
+        setInputValidationForPrefix(false);
+        setInputValidationForSuffix(false);
+        setInputValidationForWidth(false);
+        setInputValidationForHeight(false);
+        setInputValidationForResolution(false);
+        setInputValidationForFormat(false);
+    }
+
+    public void toggleSaveButton(boolean mustEnableButton){
+        buttonSave.setDisable(!mustEnableButton);
+    }
+
+    public boolean areInputsValid(){
+        return (
+            inputValidationMap.get("templateName")
+            // && inputValidationMap.get("baseName")
+            // && inputValidationMap.get("prefix")
+            // && inputValidationMap.get("suffix")
+            // && inputValidationMap.get("width")
+            // && inputValidationMap.get("height")
+            // && inputValidationMap.get("resolution")
+            // && inputValidationMap.get("format")
+        );
+    }
+
+    public void setInputValidationForTemplateName(boolean isInputValid){
+        inputValidationMap.put("templateName", isInputValid);
+    }
+    public void setInputValidationForBaseName(boolean isInputValid){
+        inputValidationMap.put("baseName", isInputValid);
+    }
+    public void setInputValidationForPrefix(boolean isInputValid){
+        inputValidationMap.put("prefix", isInputValid);
+    }
+    public void setInputValidationForSuffix(boolean isInputValid){
+        inputValidationMap.put("suffix", isInputValid);
+    }
+    public void setInputValidationForWidth(boolean isInputValid){
+        inputValidationMap.put("width", isInputValid);
+    }
+    public void setInputValidationForHeight(boolean isInputValid){
+        inputValidationMap.put("height", isInputValid);
+    }
+    public void setInputValidationForResolution(boolean isInputValid){
+        inputValidationMap.put("resolution", isInputValid);
+    }
+    public void setInputValidationForFormat(boolean isInputValid){
+        inputValidationMap.put("format", isInputValid);
     }
 }

--- a/src/main/java/com/gregorybroche/imageresolver/service/PresetManagementService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/PresetManagementService.java
@@ -1,0 +1,35 @@
+package com.gregorybroche.imageresolver.service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import com.gregorybroche.imageresolver.classes.ImageTemplate;
+import com.gregorybroche.imageresolver.classes.Preset;
+
+@Service
+public class PresetManagementService {
+    private Map<String, Preset> presets = new HashMap<String, Preset>();
+
+    public void loadPresets(){
+        Preset testPreset = new Preset("test", new ArrayList<ImageTemplate>());
+        this.presets.put(testPreset.getName(), testPreset);
+    }
+    public Map<String, Preset> getPresets() {
+        return presets;
+    }
+    public Preset getPresetByKey(String key) {
+        return presets.get(key);
+    }
+    public boolean addTemplateToPreset(ImageTemplate template, String presetKey) {
+        try {
+            presets.get(presetKey).addTemplate(template);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+        
+    }
+}

--- a/src/main/java/com/gregorybroche/imageresolver/service/PresetManagementService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/PresetManagementService.java
@@ -35,13 +35,24 @@ public class PresetManagementService {
     public Map<String, Preset> getPresets() {
         return presets;
     }
+
     public Preset getPresetFromKey(String key) {
         return presets.get(key);
     }
+
+    /**
+     * add a template to one of the loaded presets using its name key for reference
+     * @param template template to add
+     * @param presetKey name of the preset to which template must be added
+     * @return true if operation is successfull, otherwise false
+     */
     public boolean addTemplateToPreset(ImageTemplate template, String presetKey) {
         try {
-            presets.get(presetKey).addTemplate(template);
-            return true;
+            Preset presetToModify = presets.get(presetKey);
+            if (presetToModify.isTemplateNameAlreadyPresent(template.getTemplateName())) {
+                return false;
+            }
+            return presetToModify.addTemplate(template);
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/com/gregorybroche/imageresolver/service/PresetManagementService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/PresetManagementService.java
@@ -2,6 +2,7 @@ package com.gregorybroche.imageresolver.service;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
@@ -14,13 +15,27 @@ public class PresetManagementService {
     private Map<String, Preset> presets = new HashMap<String, Preset>();
 
     public void loadPresets(){
-        Preset testPreset = new Preset("test", new ArrayList<ImageTemplate>());
-        this.presets.put(testPreset.getName(), testPreset);
+        List<Preset> presetList = getPresetsFromFile();
+        setPresets(presetList);
     }
+    public void setPresets(List<Preset> presetList){
+        presetList.forEach(preset -> {
+            this.presets.put(preset.getName(), preset);
+        });
+    }
+
+    //placeholder to maintain logic, to replace with proper method once saving to file is implemented
+    public List<Preset> getPresetsFromFile(){
+        List<Preset> presetList = new ArrayList<Preset>();
+        Preset testPreset = new Preset("test", new ArrayList<ImageTemplate>());
+        presetList.add(testPreset);
+        return presetList;
+    }
+
     public Map<String, Preset> getPresets() {
         return presets;
     }
-    public Preset getPresetByKey(String key) {
+    public Preset getPresetFromKey(String key) {
         return presets.get(key);
     }
     public boolean addTemplateToPreset(ImageTemplate template, String presetKey) {

--- a/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorService.java
@@ -53,6 +53,7 @@ public class TemplateFormValidatorService {
         this.validatorService = validatorService;
         Set<String> allowedFormatsSet = validatorService.getAllowedImageFormatsAsExtension();
         this.allowedFormats = allowedFormatsSet.toArray(new String[allowedFormatsSet.size()]);
+        setAllConstraints();
     }
 
     public Map<String, InputConstraint[]> getFormConstraints() {
@@ -77,8 +78,38 @@ public class TemplateFormValidatorService {
         addInputConstraints("format", generateFormatConstraints());
     }
 
+    public ValidationResponse validateTemplateNameInput(Object input){
+        return validateInput(input,"templateName" );
+    }
+    public ValidationResponse validateWidthInput(Object input){
+        return validateInput(input,"width" );
+    }
+    public ValidationResponse validateHeightInput(Object input){
+        return validateInput(input,"height" );
+    }
+    public ValidationResponse validateResolutionInput(Object input){
+        return validateInput(input,"resolution" );
+    }
+
+    public ValidationResponse validatePrefixInput(Object input){
+        return validateInput(input,"prefix" );
+    }
+
+    public ValidationResponse validateBaseNameInput(Object input){
+        return validateInput(input,"baseName" );
+    }
+
+    public ValidationResponse validateSuffixInput(Object input){
+        return validateInput(input,"suffix" );
+    }
+
+    public ValidationResponse validateFormat(Object input){
+        return validateInput(input,"format");
+    }
+
     /**
-     * Takes in a value to compare it to a set of constraints defined my a constraint key and returns an instance of
+     * Takes in a value to compare it to a set of constraints defined my a
+     * constraint key and returns an instance of
      * ValidationResponse with properties isSuccess, data and message
      * 
      * @param input
@@ -91,8 +122,7 @@ public class TemplateFormValidatorService {
     public ValidationResponse validateInput(Object input, String inputConstraintKey) {
         InputConstraint[] inputConstraints = this.formConstraints.get(inputConstraintKey);
         for (InputConstraint inputConstraint : inputConstraints) {
-            ValidationResponse inputContraintResponse = this.validatorService.isConstraintValidated(input,
-                    inputConstraint);
+            ValidationResponse inputContraintResponse = this.validatorService.isConstraintValidated(input, inputConstraint);
             if (!inputContraintResponse.getIsSuccess()) {
                 return inputContraintResponse;
             }

--- a/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorService.java
@@ -80,35 +80,35 @@ public class TemplateFormValidatorService {
         addInputConstraints("format", generateFormatConstraints());
     }
 
-    public ValidationResponse validateTemplateNameInput(Object input) {
+    public ValidationResponse validateTemplateNameInput(String input) {
         return validateInput(input, "templateName");
     }
 
-    public ValidationResponse validateWidthInput(Object input) {
+    public ValidationResponse validateWidthInput(String input) {
         return validateInput(input, "width");
     }
 
-    public ValidationResponse validateHeightInput(Object input) {
+    public ValidationResponse validateHeightInput(String input) {
         return validateInput(input, "height");
     }
 
-    public ValidationResponse validateResolutionInput(Object input) {
+    public ValidationResponse validateResolutionInput(String input) {
         return validateInput(input, "resolution");
     }
 
-    public ValidationResponse validatePrefixInput(Object input) {
+    public ValidationResponse validatePrefixInput(String input) {
         return validateInput(input, "prefix");
     }
 
-    public ValidationResponse validateBaseNameInput(Object input) {
+    public ValidationResponse validateBaseNameInput(String input) {
         return validateInput(input, "baseName");
     }
 
-    public ValidationResponse validateSuffixInput(Object input) {
+    public ValidationResponse validateSuffixInput(String input) {
         return validateInput(input, "suffix");
     }
 
-    public ValidationResponse validateFormatInput(Object input) {
+    public ValidationResponse validateFormatInput(String input) {
         return validateInput(input, "format");
     }
 
@@ -124,11 +124,12 @@ public class TemplateFormValidatorService {
      *         the message corresponding to the failed constraint error message,
      *         otherwise isSuccess will be true and message is null
      */
-    public ValidationResponse validateInput(Object input, String inputConstraintKey) {
+    public ValidationResponse validateInput(String input, String inputConstraintKey) {
         try {
             InputConstraint[] inputConstraints = this.formConstraints.get(inputConstraintKey);
             for (InputConstraint inputConstraint : inputConstraints) {
-                ValidationResponse inputContraintResponse = this.validatorService.isConstraintValidated(input, inputConstraint);
+                ValidationResponse inputContraintResponse = this.validatorService.isConstraintValidated(input,
+                        inputConstraint);
                 if (!inputContraintResponse.getIsSuccess()) {
                     return inputContraintResponse;
                 }
@@ -180,6 +181,11 @@ public class TemplateFormValidatorService {
                 this.isWidthRequired,
                 "The width is required"));
         templateWidthConstraints.add(new InputConstraint(
+                "widthMustBeInteger",
+                ConstraintType.IS_INTEGER_STRING,
+                true,
+                "The width must be a valid integer"));
+        templateWidthConstraints.add(new InputConstraint(
                 "minimumWidth",
                 ConstraintType.GREATER_THAN,
                 this.minWidth,
@@ -199,6 +205,11 @@ public class TemplateFormValidatorService {
                 ConstraintType.REQUIRED,
                 this.isResolutionRequired,
                 "The height is required"));
+        templateHeightConstraints.add(new InputConstraint(
+                "heightMustBeInteger",
+                ConstraintType.IS_INTEGER_STRING,
+                true,
+                "The height must be a valid integer"));
         templateHeightConstraints.add(new InputConstraint(
                 "minimumHeight",
                 ConstraintType.GREATER_THAN,

--- a/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorService.java
@@ -15,6 +15,7 @@ import com.gregorybroche.imageresolver.classes.ValidationResponse;
 @Service
 public class TemplateFormValidatorService {
     private ValidatorService validatorService;
+    private UserDialogService userDialogService;
 
     private boolean isTemplateNameRequired = true;
     private int minLengthTemplateName = 1;
@@ -49,8 +50,9 @@ public class TemplateFormValidatorService {
 
     private final Map<String, InputConstraint[]> formConstraints = new HashMap<String, InputConstraint[]>();
 
-    public TemplateFormValidatorService(ValidatorService validatorService) {
+    public TemplateFormValidatorService(ValidatorService validatorService, UserDialogService userDialogService) {
         this.validatorService = validatorService;
+        this.userDialogService = userDialogService;
         Set<String> allowedFormatsSet = validatorService.getAllowedImageFormatsAsExtension();
         this.allowedFormats = allowedFormatsSet.toArray(new String[allowedFormatsSet.size()]);
         setAllConstraints();
@@ -78,33 +80,36 @@ public class TemplateFormValidatorService {
         addInputConstraints("format", generateFormatConstraints());
     }
 
-    public ValidationResponse validateTemplateNameInput(Object input){
-        return validateInput(input,"templateName" );
-    }
-    public ValidationResponse validateWidthInput(Object input){
-        return validateInput(input,"width" );
-    }
-    public ValidationResponse validateHeightInput(Object input){
-        return validateInput(input,"height" );
-    }
-    public ValidationResponse validateResolutionInput(Object input){
-        return validateInput(input,"resolution" );
+    public ValidationResponse validateTemplateNameInput(Object input) {
+        return validateInput(input, "templateName");
     }
 
-    public ValidationResponse validatePrefixInput(Object input){
-        return validateInput(input,"prefix" );
+    public ValidationResponse validateWidthInput(Object input) {
+        return validateInput(input, "width");
     }
 
-    public ValidationResponse validateBaseNameInput(Object input){
-        return validateInput(input,"baseName" );
+    public ValidationResponse validateHeightInput(Object input) {
+        return validateInput(input, "height");
     }
 
-    public ValidationResponse validateSuffixInput(Object input){
-        return validateInput(input,"suffix" );
+    public ValidationResponse validateResolutionInput(Object input) {
+        return validateInput(input, "resolution");
     }
 
-    public ValidationResponse validateFormat(Object input){
-        return validateInput(input,"format");
+    public ValidationResponse validatePrefixInput(Object input) {
+        return validateInput(input, "prefix");
+    }
+
+    public ValidationResponse validateBaseNameInput(Object input) {
+        return validateInput(input, "baseName");
+    }
+
+    public ValidationResponse validateSuffixInput(Object input) {
+        return validateInput(input, "suffix");
+    }
+
+    public ValidationResponse validateFormatInput(Object input) {
+        return validateInput(input, "format");
     }
 
     /**
@@ -120,13 +125,18 @@ public class TemplateFormValidatorService {
      *         otherwise isSuccess will be true and message is null
      */
     public ValidationResponse validateInput(Object input, String inputConstraintKey) {
-        InputConstraint[] inputConstraints = this.formConstraints.get(inputConstraintKey);
-        for (InputConstraint inputConstraint : inputConstraints) {
-            ValidationResponse inputContraintResponse = this.validatorService.isConstraintValidated(input, inputConstraint);
-            if (!inputContraintResponse.getIsSuccess()) {
-                return inputContraintResponse;
+        try {
+            InputConstraint[] inputConstraints = this.formConstraints.get(inputConstraintKey);
+            for (InputConstraint inputConstraint : inputConstraints) {
+                ValidationResponse inputContraintResponse = this.validatorService.isConstraintValidated(input, inputConstraint);
+                if (!inputContraintResponse.getIsSuccess()) {
+                    return inputContraintResponse;
+                }
             }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
+
         return new ValidationResponse(true, null, null);
     }
 
@@ -236,7 +246,7 @@ public class TemplateFormValidatorService {
                 "The prefix must be longer than " + this.minLengthImagePrefix + " characters"));
         templateImagePrefixConstraints.add(new InputConstraint(
                 "maximumPrefixLength",
-                ConstraintType.LESS_THAN,
+                ConstraintType.SHORTER_THAN,
                 this.maxLengthImagePrefix,
                 "The prefix must be shorter than " + this.minLengthImagePrefix + " characters"));
         return templateImagePrefixConstraints
@@ -258,7 +268,7 @@ public class TemplateFormValidatorService {
                         + " characters"));
         templateImageBaseNameConstraints.add(new InputConstraint(
                 "maximumPrefixLength",
-                ConstraintType.LESS_THAN,
+                ConstraintType.SHORTER_THAN,
                 this.maxLengthImageBaseName,
                 "The image base name must be shorter than " + this.maxLengthImageBaseName
                         + " characters"));
@@ -280,7 +290,7 @@ public class TemplateFormValidatorService {
                 "The suffix must be longer than " + this.minLengthImageSuffix + " characters"));
         templateImageSuffixConstraints.add(new InputConstraint(
                 "maximumSuffixLength",
-                ConstraintType.LESS_THAN,
+                ConstraintType.SHORTER_THAN,
                 this.maxLengthImageSuffix,
                 "The suffix must be shorter than " + this.minLengthImageSuffix + " characters"));
         return templateImageSuffixConstraints

--- a/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorService.java
@@ -13,7 +13,7 @@ import com.gregorybroche.imageresolver.classes.InputConstraint;
 import com.gregorybroche.imageresolver.classes.ValidationResponse;
 
 @Service
-public class TemplateSubmitterService {
+public class TemplateFormValidatorService {
     private ValidatorService validatorService;
 
     private boolean isTemplateNameRequired = true;
@@ -49,7 +49,7 @@ public class TemplateSubmitterService {
 
     private final Map<String, InputConstraint[]> formConstraints = new HashMap<String, InputConstraint[]>();
 
-    public TemplateSubmitterService(ValidatorService validatorService) {
+    public TemplateFormValidatorService(ValidatorService validatorService) {
         this.validatorService = validatorService;
         Set<String> allowedFormatsSet = validatorService.getAllowedImageFormatsAsExtension();
         this.allowedFormats = allowedFormatsSet.toArray(new String[allowedFormatsSet.size()]);

--- a/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorService.java
@@ -42,7 +42,7 @@ public class TemplateFormValidatorService {
     private int maxLengthImageSuffix = 16;
 
     private boolean isImageBaseNameRequired = true;
-    private int minLengthImageBaseName = 5;
+    private int minLengthImageBaseName = 3;
     private int maxLengthImageBaseName = 50;
 
     private boolean isFormatRequired = true;

--- a/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorService.java
@@ -66,6 +66,31 @@ public class TemplateFormValidatorService {
         return this.allowedFormats;
     }
 
+    public boolean isTemplateNameRequired(){
+        return this.isTemplateNameRequired;
+    }
+    public boolean isWidthRequired(){
+        return this.isWidthRequired;
+    }
+    public boolean isHeightRequired(){
+        return this.isHeightRequired;
+    }
+    public boolean isResolutionRequired(){
+        return this.isResolutionRequired;
+    }
+    public boolean isImagePrefixRequired(){
+        return this.isImagePrefixRequired;
+    }
+    public boolean isImageSuffixRequired(){
+        return this.isImageSuffixRequired;
+    }
+    public boolean isImageBaseNameRequired(){
+        return this.isImageBaseNameRequired;
+    }
+    public boolean isFormatRequired(){
+        return this.isFormatRequired;
+    }
+
     /**
      * Set constraints required for all inputs
      */

--- a/src/main/java/com/gregorybroche/imageresolver/service/TemplateSubmitterService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/TemplateSubmitterService.java
@@ -1,0 +1,89 @@
+package com.gregorybroche.imageresolver.service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+
+import com.gregorybroche.imageresolver.Enums.ConstraintType;
+import com.gregorybroche.imageresolver.classes.InputConstraint;
+
+@Service
+public class TemplateSubmitterService {
+    private ValidatorService validatorService;
+
+    private boolean isTemplateNameRequired = true;
+    private int minLengthTemplateName = 1;
+    private int maxLengthTemplateName = 20;
+
+    private boolean isWidthRequired = true;
+    private int minWidth = 16;
+    private int maxWidth = 10000;
+
+    private boolean isHeigthRequired = true;
+    private int minHeigth = 16;
+    private int maxHeigth = 10000;
+
+    private boolean isResolutionRequired = true;
+    private int minResolution = 70;
+    private int maxResolution = 300;
+
+    private boolean isImagePrefixRequired = false;
+    private int minLengthImagePrefix = 1;
+    private int maxLengthImagePrefix = 16;
+
+    private boolean isImageSuffixRequired = false;
+    private int minLengthImageSuffix = 1;
+    private int maxLengthImageSuffix = 16;
+
+    private boolean isImageBaseNameRequired = true;
+    private int minLengthImageBaseName = 5;
+    private int maxLengthImageBaseName = 50;
+
+    private boolean isFormatRequired = true;
+    private String[] allowedFormats;
+
+    private final Map<String, InputConstraint[]> formConstraints = new HashMap<String, InputConstraint[]>();
+
+    public TemplateSubmitterService(ValidatorService validatorService) {
+        this.validatorService = validatorService;
+        Set<String> allowedFormatsSet = validatorService.getAllowedImageFormatsAsExtension();
+        this.allowedFormats = allowedFormatsSet.toArray(new String[allowedFormatsSet.size()]);
+    }
+
+    public Map<String, InputConstraint[]>  getFormConstraints(){
+        return this.formConstraints;
+    }
+
+    public void setAllConstraints(){
+        addInputConstraints("templateName", generateTemplateNameConstraints());
+    }
+
+    public void addInputConstraints(String inputKey, InputConstraint[] constraints){
+        this.formConstraints.put(inputKey, constraints);
+    }
+
+    private InputConstraint[] generateTemplateNameConstraints() {
+        List<InputConstraint> templateNameConstraints = new ArrayList<InputConstraint>();
+        templateNameConstraints.add(new InputConstraint(
+                "requiredTemplateName",
+                ConstraintType.REQUIRED,
+                this.isTemplateNameRequired,
+                "The template name is required"));
+        templateNameConstraints.add(new InputConstraint(
+                    "minimumTemplateName",
+                    ConstraintType.LONGER_THAN,
+                    this.minLengthTemplateName,
+                    "The template name must be longer than "+this.minLengthTemplateName+" characters"));
+        templateNameConstraints.add(new InputConstraint(
+                    "maximumTemplateName",
+                    ConstraintType.SHORTER_THAN,
+                    this.maxLengthTemplateName,
+                    "The template name must be short than "+this.maxLengthTemplateName+" characters"));
+        return templateNameConstraints.toArray(new InputConstraint[templateNameConstraints.size()]);
+    }
+}

--- a/src/main/java/com/gregorybroche/imageresolver/service/TemplateSubmitterService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/TemplateSubmitterService.java
@@ -2,7 +2,6 @@ package com.gregorybroche.imageresolver.service;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -11,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 import com.gregorybroche.imageresolver.Enums.ConstraintType;
 import com.gregorybroche.imageresolver.classes.InputConstraint;
+import com.gregorybroche.imageresolver.classes.ValidationResponse;
 
 @Service
 public class TemplateSubmitterService {
@@ -59,10 +59,13 @@ public class TemplateSubmitterService {
         return this.formConstraints;
     }
 
-    public String[] getAllowedFormats(){
+    public String[] getAllowedFormats() {
         return this.allowedFormats;
     }
 
+    /**
+     * Set constraints required for all inputs
+     */
     public void setAllConstraints() {
         addInputConstraints("templateName", generateTemplateNameConstraints());
         addInputConstraints("width", generateWidthConstraints());
@@ -74,6 +77,31 @@ public class TemplateSubmitterService {
         addInputConstraints("format", generateFormatConstraints());
     }
 
+    /**
+     * Takes in a value to compare it to a set of constraints defined my a constraint key and returns an 
+     * instance of ValidationResponse with properties isSuccess, data and message
+     * @param input 
+     * @param inputConstraintKey key correspondind to the constraints defined in setAllConstraints
+     * @return if a constraint check failed return will have isSuccess at false and the message corresponding to the failed constraint error message,
+     * otherwise isSuccess will be true and message is null
+     */
+    public ValidationResponse validateInput(Object input, String inputConstraintKey) {
+        InputConstraint[] inputConstraints = this.formConstraints.get(inputConstraintKey);
+        for (InputConstraint inputConstraint : inputConstraints) {
+            ValidationResponse inputContraintResponse = this.validatorService.isConstraintValidated(input,
+                    inputConstraint);
+            if (!inputContraintResponse.getIsSuccess()) {
+                return inputContraintResponse;
+            }
+        }
+        return new ValidationResponse(true, null, null);
+    }
+
+    /**
+     * Adds all constraints relative to a specific input
+     * @param inputKey key reference for the map collection <String, InputConstraint[]> formConstraints and corresponding to the input
+     * @param constraints array of InputConstraint
+     */
     private void addInputConstraints(String inputKey, InputConstraint[] constraints) {
         this.formConstraints.put(inputKey, constraints);
     }

--- a/src/main/java/com/gregorybroche/imageresolver/service/TemplateSubmitterService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/TemplateSubmitterService.java
@@ -24,9 +24,9 @@ public class TemplateSubmitterService {
     private int minWidth = 16;
     private int maxWidth = 10000;
 
-    private boolean isHeigthRequired = true;
-    private int minHeigth = 16;
-    private int maxHeigth = 10000;
+    private boolean isHeightRequired = true;
+    private int minHeight = 16;
+    private int maxHeight = 10000;
 
     private boolean isResolutionRequired = true;
     private int minResolution = 70;
@@ -55,15 +55,22 @@ public class TemplateSubmitterService {
         this.allowedFormats = allowedFormatsSet.toArray(new String[allowedFormatsSet.size()]);
     }
 
-    public Map<String, InputConstraint[]>  getFormConstraints(){
+    public Map<String, InputConstraint[]> getFormConstraints() {
         return this.formConstraints;
     }
 
-    public void setAllConstraints(){
+    public void setAllConstraints() {
         addInputConstraints("templateName", generateTemplateNameConstraints());
+        addInputConstraints("width", generateWidthConstraints());
+        addInputConstraints("height", generateHeightConstraints());
+        addInputConstraints("resolution", generateResolutionConstraints());
+        addInputConstraints("prefix", generateImagePrefixConstraints());
+        addInputConstraints("baseName", generateImageBaseNameConstraints());
+        addInputConstraints("suffix", generateImageSuffixConstraints());
+        addInputConstraints("format", generateFormatConstraints());
     }
 
-    public void addInputConstraints(String inputKey, InputConstraint[] constraints){
+    private void addInputConstraints(String inputKey, InputConstraint[] constraints) {
         this.formConstraints.put(inputKey, constraints);
     }
 
@@ -75,15 +82,150 @@ public class TemplateSubmitterService {
                 this.isTemplateNameRequired,
                 "The template name is required"));
         templateNameConstraints.add(new InputConstraint(
-                    "minimumTemplateName",
-                    ConstraintType.LONGER_THAN,
-                    this.minLengthTemplateName,
-                    "The template name must be longer than "+this.minLengthTemplateName+" characters"));
+                "minimumTemplateName",
+                ConstraintType.LONGER_THAN,
+                this.minLengthTemplateName,
+                "The template name must be longer than " + this.minLengthTemplateName + " characters"));
         templateNameConstraints.add(new InputConstraint(
-                    "maximumTemplateName",
-                    ConstraintType.SHORTER_THAN,
-                    this.maxLengthTemplateName,
-                    "The template name must be short than "+this.maxLengthTemplateName+" characters"));
+                "maximumTemplateName",
+                ConstraintType.SHORTER_THAN,
+                this.maxLengthTemplateName,
+                "The template name must be short than " + this.maxLengthTemplateName + " characters"));
         return templateNameConstraints.toArray(new InputConstraint[templateNameConstraints.size()]);
+    }
+
+    private InputConstraint[] generateWidthConstraints() {
+        List<InputConstraint> templateWidthConstraints = new ArrayList<InputConstraint>();
+        templateWidthConstraints.add(new InputConstraint(
+                "requiredWidth",
+                ConstraintType.REQUIRED,
+                this.isWidthRequired,
+                "The width is required"));
+        templateWidthConstraints.add(new InputConstraint(
+                "minimumWidth",
+                ConstraintType.GREATER_THAN,
+                this.minWidth,
+                "The width must be an int greater than " + this.minWidth));
+        templateWidthConstraints.add(new InputConstraint(
+                "maximumWidth",
+                ConstraintType.LESS_THAN,
+                this.maxWidth,
+                "The width must be an int less than " + this.maxWidth));
+        return templateWidthConstraints.toArray(new InputConstraint[templateWidthConstraints.size()]);
+    }
+
+    private InputConstraint[] generateHeightConstraints() {
+        List<InputConstraint> templateHeightConstraints = new ArrayList<InputConstraint>();
+        templateHeightConstraints.add(new InputConstraint(
+                "requiredHeight",
+                ConstraintType.REQUIRED,
+                this.isResolutionRequired,
+                "The height is required"));
+        templateHeightConstraints.add(new InputConstraint(
+                "minimumHeight",
+                ConstraintType.GREATER_THAN,
+                this.minHeight,
+                "The height must be an int greater than " + this.minHeight));
+        templateHeightConstraints.add(new InputConstraint(
+                "maximumHeight",
+                ConstraintType.LESS_THAN,
+                this.maxHeight,
+                "The height must be an int less than " + this.maxHeight));
+        return templateHeightConstraints.toArray(new InputConstraint[templateHeightConstraints.size()]);
+    }
+
+    private InputConstraint[] generateResolutionConstraints() {
+        List<InputConstraint> templateResolutionConstraints = new ArrayList<InputConstraint>();
+        templateResolutionConstraints.add(new InputConstraint(
+                "requiredResolution",
+                ConstraintType.REQUIRED,
+                this.isHeightRequired,
+                "The resolution is required"));
+        templateResolutionConstraints.add(new InputConstraint(
+                "minimumResolution",
+                ConstraintType.GREATER_THAN,
+                this.minResolution,
+                "The resolution must be an int greater than " + this.minResolution));
+        templateResolutionConstraints.add(new InputConstraint(
+                "maximumResolution",
+                ConstraintType.LESS_THAN,
+                this.maxResolution,
+                "The resolution must be an int less than " + this.maxResolution));
+        return templateResolutionConstraints.toArray(new InputConstraint[templateResolutionConstraints.size()]);
+    }
+    
+    private InputConstraint[] generateImagePrefixConstraints() {
+        List<InputConstraint> templateImagePrefixConstraints = new ArrayList<InputConstraint>();
+        templateImagePrefixConstraints.add(new InputConstraint(
+                "requiredImagePrefix",
+                ConstraintType.REQUIRED,
+                this.isImagePrefixRequired,
+                "The image name prefix is required"));
+                templateImagePrefixConstraints.add(new InputConstraint(
+                "minimumPrefixLength",
+                ConstraintType.LONGER_THAN,
+                this.minLengthImagePrefix,
+                "The prefix must be longer than " + this.minLengthImagePrefix + " characters"));
+                templateImagePrefixConstraints.add(new InputConstraint(
+                "maximumPrefixLength",
+                ConstraintType.LESS_THAN,
+                this.maxLengthImagePrefix,
+                "The prefix must be shorter than " + this.minLengthImagePrefix + " characters"));
+        return templateImagePrefixConstraints.toArray(new InputConstraint[templateImagePrefixConstraints.size()]);
+    }
+    
+    private InputConstraint[] generateImageBaseNameConstraints() {
+        List<InputConstraint> templateImageBaseNameConstraints = new ArrayList<InputConstraint>();
+        templateImageBaseNameConstraints.add(new InputConstraint(
+                "requiredImageBaseName",
+                ConstraintType.REQUIRED,
+                this.isImageBaseNameRequired,
+                "The image base name is required"));
+                templateImageBaseNameConstraints.add(new InputConstraint(
+                "minimumBaseNameLength",
+                ConstraintType.LONGER_THAN,
+                this.minLengthImageBaseName,
+                "The image base name must be longer than " + this.minLengthImageBaseName + " characters"));
+                templateImageBaseNameConstraints.add(new InputConstraint(
+                "maximumPrefixLength",
+                ConstraintType.LESS_THAN,
+                this.maxLengthImageBaseName,
+                "The image base name must be shorter than " + this.maxLengthImageBaseName + " characters"));
+        return templateImageBaseNameConstraints.toArray(new InputConstraint[templateImageBaseNameConstraints.size()]);
+    }
+        
+    private InputConstraint[] generateImageSuffixConstraints() {
+        List<InputConstraint> templateImageSuffixConstraints = new ArrayList<InputConstraint>();
+        templateImageSuffixConstraints.add(new InputConstraint(
+                "requiredImageSuffix",
+                ConstraintType.REQUIRED,
+                this.isImageSuffixRequired,
+                "The image name suffix is required"));
+                templateImageSuffixConstraints.add(new InputConstraint(
+                "minimumSuffixLength",
+                ConstraintType.LONGER_THAN,
+                this.minLengthImageSuffix,
+                "The suffix must be longer than " + this.minLengthImageSuffix + " characters"));
+                templateImageSuffixConstraints.add(new InputConstraint(
+                "maximumSuffixLength",
+                ConstraintType.LESS_THAN,
+                this.maxLengthImageSuffix,
+                "The suffix must be shorter than " + this.minLengthImageSuffix + " characters"));
+        return templateImageSuffixConstraints.toArray(new InputConstraint[templateImageSuffixConstraints.size()]);
+    }
+
+    private InputConstraint[] generateFormatConstraints() {
+        List<InputConstraint> templateFormatConstraints = new ArrayList<InputConstraint>();
+        templateFormatConstraints.add(new InputConstraint(
+                "requiredFormat",
+                ConstraintType.REQUIRED,
+                this.isFormatRequired,
+                "The format is required"));
+                templateFormatConstraints.add(new InputConstraint(
+                "allowedFormat",
+                ConstraintType.INCLUDED_IN,
+                this.allowedFormats,
+                "The format must be one of the allowed formats"));
+        return templateFormatConstraints.toArray(new InputConstraint[templateFormatConstraints.size()]);
     }
 }

--- a/src/main/java/com/gregorybroche/imageresolver/service/TemplateSubmitterService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/TemplateSubmitterService.java
@@ -59,6 +59,10 @@ public class TemplateSubmitterService {
         return this.formConstraints;
     }
 
+    public String[] getAllowedFormats(){
+        return this.allowedFormats;
+    }
+
     public void setAllConstraints() {
         addInputConstraints("templateName", generateTemplateNameConstraints());
         addInputConstraints("width", generateWidthConstraints());
@@ -153,7 +157,7 @@ public class TemplateSubmitterService {
                 "The resolution must be an int less than " + this.maxResolution));
         return templateResolutionConstraints.toArray(new InputConstraint[templateResolutionConstraints.size()]);
     }
-    
+
     private InputConstraint[] generateImagePrefixConstraints() {
         List<InputConstraint> templateImagePrefixConstraints = new ArrayList<InputConstraint>();
         templateImagePrefixConstraints.add(new InputConstraint(
@@ -161,19 +165,20 @@ public class TemplateSubmitterService {
                 ConstraintType.REQUIRED,
                 this.isImagePrefixRequired,
                 "The image name prefix is required"));
-                templateImagePrefixConstraints.add(new InputConstraint(
+        templateImagePrefixConstraints.add(new InputConstraint(
                 "minimumPrefixLength",
                 ConstraintType.LONGER_THAN,
                 this.minLengthImagePrefix,
                 "The prefix must be longer than " + this.minLengthImagePrefix + " characters"));
-                templateImagePrefixConstraints.add(new InputConstraint(
+        templateImagePrefixConstraints.add(new InputConstraint(
                 "maximumPrefixLength",
                 ConstraintType.LESS_THAN,
                 this.maxLengthImagePrefix,
                 "The prefix must be shorter than " + this.minLengthImagePrefix + " characters"));
-        return templateImagePrefixConstraints.toArray(new InputConstraint[templateImagePrefixConstraints.size()]);
+        return templateImagePrefixConstraints
+                .toArray(new InputConstraint[templateImagePrefixConstraints.size()]);
     }
-    
+
     private InputConstraint[] generateImageBaseNameConstraints() {
         List<InputConstraint> templateImageBaseNameConstraints = new ArrayList<InputConstraint>();
         templateImageBaseNameConstraints.add(new InputConstraint(
@@ -181,19 +186,22 @@ public class TemplateSubmitterService {
                 ConstraintType.REQUIRED,
                 this.isImageBaseNameRequired,
                 "The image base name is required"));
-                templateImageBaseNameConstraints.add(new InputConstraint(
+        templateImageBaseNameConstraints.add(new InputConstraint(
                 "minimumBaseNameLength",
                 ConstraintType.LONGER_THAN,
                 this.minLengthImageBaseName,
-                "The image base name must be longer than " + this.minLengthImageBaseName + " characters"));
-                templateImageBaseNameConstraints.add(new InputConstraint(
+                "The image base name must be longer than " + this.minLengthImageBaseName
+                        + " characters"));
+        templateImageBaseNameConstraints.add(new InputConstraint(
                 "maximumPrefixLength",
                 ConstraintType.LESS_THAN,
                 this.maxLengthImageBaseName,
-                "The image base name must be shorter than " + this.maxLengthImageBaseName + " characters"));
-        return templateImageBaseNameConstraints.toArray(new InputConstraint[templateImageBaseNameConstraints.size()]);
+                "The image base name must be shorter than " + this.maxLengthImageBaseName
+                        + " characters"));
+        return templateImageBaseNameConstraints
+                .toArray(new InputConstraint[templateImageBaseNameConstraints.size()]);
     }
-        
+
     private InputConstraint[] generateImageSuffixConstraints() {
         List<InputConstraint> templateImageSuffixConstraints = new ArrayList<InputConstraint>();
         templateImageSuffixConstraints.add(new InputConstraint(
@@ -201,17 +209,18 @@ public class TemplateSubmitterService {
                 ConstraintType.REQUIRED,
                 this.isImageSuffixRequired,
                 "The image name suffix is required"));
-                templateImageSuffixConstraints.add(new InputConstraint(
+        templateImageSuffixConstraints.add(new InputConstraint(
                 "minimumSuffixLength",
                 ConstraintType.LONGER_THAN,
                 this.minLengthImageSuffix,
                 "The suffix must be longer than " + this.minLengthImageSuffix + " characters"));
-                templateImageSuffixConstraints.add(new InputConstraint(
+        templateImageSuffixConstraints.add(new InputConstraint(
                 "maximumSuffixLength",
                 ConstraintType.LESS_THAN,
                 this.maxLengthImageSuffix,
                 "The suffix must be shorter than " + this.minLengthImageSuffix + " characters"));
-        return templateImageSuffixConstraints.toArray(new InputConstraint[templateImageSuffixConstraints.size()]);
+        return templateImageSuffixConstraints
+                .toArray(new InputConstraint[templateImageSuffixConstraints.size()]);
     }
 
     private InputConstraint[] generateFormatConstraints() {
@@ -221,7 +230,7 @@ public class TemplateSubmitterService {
                 ConstraintType.REQUIRED,
                 this.isFormatRequired,
                 "The format is required"));
-                templateFormatConstraints.add(new InputConstraint(
+        templateFormatConstraints.add(new InputConstraint(
                 "allowedFormat",
                 ConstraintType.INCLUDED_IN,
                 this.allowedFormats,

--- a/src/main/java/com/gregorybroche/imageresolver/service/TemplateSubmitterService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/TemplateSubmitterService.java
@@ -78,12 +78,15 @@ public class TemplateSubmitterService {
     }
 
     /**
-     * Takes in a value to compare it to a set of constraints defined my a constraint key and returns an 
-     * instance of ValidationResponse with properties isSuccess, data and message
-     * @param input 
-     * @param inputConstraintKey key correspondind to the constraints defined in setAllConstraints
-     * @return if a constraint check failed return will have isSuccess at false and the message corresponding to the failed constraint error message,
-     * otherwise isSuccess will be true and message is null
+     * Takes in a value to compare it to a set of constraints defined my a constraint key and returns an instance of
+     * ValidationResponse with properties isSuccess, data and message
+     * 
+     * @param input
+     * @param inputConstraintKey key correspondind to the constraints defined in
+     *                           setAllConstraints
+     * @return if a constraint check failed return will have isSuccess at false and
+     *         the message corresponding to the failed constraint error message,
+     *         otherwise isSuccess will be true and message is null
      */
     public ValidationResponse validateInput(Object input, String inputConstraintKey) {
         InputConstraint[] inputConstraints = this.formConstraints.get(inputConstraintKey);
@@ -99,7 +102,10 @@ public class TemplateSubmitterService {
 
     /**
      * Adds all constraints relative to a specific input
-     * @param inputKey key reference for the map collection <String, InputConstraint[]> formConstraints and corresponding to the input
+     * 
+     * @param inputKey    key reference for the map collection <String,
+     *                    InputConstraint[]> formConstraints and corresponding to
+     *                    the input
      * @param constraints array of InputConstraint
      */
     private void addInputConstraints(String inputKey, InputConstraint[] constraints) {

--- a/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
@@ -89,35 +89,35 @@ public class ValidatorService {
      * @return ValidationReponse instance with a success state, possible data object
      *         array, and possible error message
      */
-    public ValidationResponse isConstraintValidated(Object input, InputConstraint inputConstraint) throws Exception {
+    public ValidationResponse isConstraintValidated(String input, InputConstraint inputConstraint) throws Exception {
         boolean isConstraintValid = false;
         switch (inputConstraint.getConstraintType()) {
             case REQUIRED:
                 isConstraintValid = (Boolean) inputConstraint.getValue() ? isNotEmpty(input) : true;
                 break;
 
+            case IS_INTEGER_STRING:
+                isConstraintValid = input == null || isStringValidInteger(input.toString());
+                break;
+
             case GREATER_THAN:
-                System.out.println("greater than case");
-                isConstraintValid = isGreaterThan(input, (Integer) inputConstraint.getValue());
+                isConstraintValid = input == null || isGreaterThan(sanitizeStringAsInteger(input), (Integer) inputConstraint.getValue());
                 break;
 
             case LESS_THAN:
-                System.out.println("less than case");
-                isConstraintValid = isLessThan(input, (Integer) inputConstraint.getValue());
+                isConstraintValid = input == null || isLessThan(sanitizeStringAsInteger(input), (Integer) inputConstraint.getValue());
                 break;
 
             case LONGER_THAN:
-                System.out.println("longer than case");
-                isConstraintValid = isLongerThan(input, (Integer) inputConstraint.getValue());
+                isConstraintValid = input == null || isLongerThan(input, (Integer) inputConstraint.getValue());
                 break;
 
             case SHORTER_THAN:
-                System.out.println("shorter than case");
-                isConstraintValid = isShorterThan(input, (Integer) inputConstraint.getValue());
+                isConstraintValid = input == null || isShorterThan(input, (Integer) inputConstraint.getValue());
                 break;
 
             case INCLUDED_IN:
-                isConstraintValid = isIncludedIn(input, (Object[]) inputConstraint.getValue());
+                isConstraintValid = input == null || isIncludedIn(input, (Object[]) inputConstraint.getValue());
                 break;
 
             default:

--- a/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
@@ -108,6 +108,10 @@ public class ValidatorService {
                 isConstraintValid = isShorterThan(input, (Integer) constraintValue);
                 break;
 
+            case INCLUDED_IN:
+                isConstraintValid = isIncludedIn(input, (Object[]) constraintValue);
+                break;
+
             default:
                 break;
         }
@@ -180,12 +184,21 @@ public class ValidatorService {
         return input.toString().length() <= maxLen;
     }
 
-    // public boolean isIncludedIn(Object input, Object[] allowedValues) {
-    //     for (Object allowedValue : allowedValues) {
-    //         if (input.equals(allowedValue)) {
-    //             return true;
-    //         }
-    //     }
-    //     return false;
-    // }
+    /**
+     * Validates if an input is equal to an object contained in an array
+     * @param input Object to evaluate
+     * @param allowedValues haystack
+     * @return true if object is found in collection
+     */
+    public boolean isIncludedIn(Object input, Object[] allowedValues) {
+        if(input == null){
+            return false;
+        }
+        for (Object allowedValue : allowedValues) {
+            if (input.equals(allowedValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
@@ -56,7 +56,7 @@ public class ValidatorService {
     }
 
     /**
-     * return List of allowed image extension with syntax like "webp"
+     * return set of allowed image extension with syntax like "webp"
      * 
      * @return
      */

--- a/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
@@ -85,7 +85,7 @@ public class ValidatorService {
      * @param input Input to validate, accepts Object to cover all case
      * @param constraintValue Value of the constraint, accepts Object to cover all case
      * @param constraintType Type of the constraint based on an enum
-     * @return True if input is compliant with the constraint
+     * @return ValidationReponse instance with a success state, possible data object array, and possible error message
      */
     public ValidationResponse isConstraintValidated(Object input, InputConstraint inputConstraint) {
         boolean isConstraintValid = false;

--- a/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
@@ -81,31 +81,38 @@ public class ValidatorService {
 
     /**
      * Validates if an input complies with a constraint
-     * @param input Input to validate, accepts Object to cover all case
-     * @param constraintValue Value of the constraint, accepts Object to cover all case
-     * @param constraintType Type of the constraint based on an enum
-     * @return ValidationReponse instance with a success state, possible data object array, and possible error message
+     * 
+     * @param input           Input to validate, accepts Object to cover all case
+     * @param constraintValue Value of the constraint, accepts Object to cover all
+     *                        case
+     * @param constraintType  Type of the constraint based on an enum
+     * @return ValidationReponse instance with a success state, possible data object
+     *         array, and possible error message
      */
-    public ValidationResponse isConstraintValidated(Object input, InputConstraint inputConstraint) {
+    public ValidationResponse isConstraintValidated(Object input, InputConstraint inputConstraint) throws Exception {
         boolean isConstraintValid = false;
         switch (inputConstraint.getConstraintType()) {
             case REQUIRED:
-                isConstraintValid = isNotEmpty(input);
+                isConstraintValid = (Boolean) inputConstraint.getValue() ? isNotEmpty(input) : true;
                 break;
 
             case GREATER_THAN:
+                System.out.println("greater than case");
                 isConstraintValid = isGreaterThan(input, (Integer) inputConstraint.getValue());
                 break;
 
             case LESS_THAN:
+                System.out.println("less than case");
                 isConstraintValid = isLessThan(input, (Integer) inputConstraint.getValue());
                 break;
 
             case LONGER_THAN:
+                System.out.println("longer than case");
                 isConstraintValid = isLongerThan(input, (Integer) inputConstraint.getValue());
                 break;
 
             case SHORTER_THAN:
+                System.out.println("shorter than case");
                 isConstraintValid = isShorterThan(input, (Integer) inputConstraint.getValue());
                 break;
 
@@ -117,18 +124,20 @@ public class ValidatorService {
                 break;
         }
         return isConstraintValid
-            ? new ValidationResponse(true, null, null)
-            : new ValidationResponse(false, null, inputConstraint.getErrorMessage());
+                ? new ValidationResponse(true, null, null)
+                : new ValidationResponse(false, null, inputConstraint.getErrorMessage());
     }
 
     /**
      * Sanitize and parses a string as an integer
+     * 
      * @param string String to parse
-     * @return null if string is not valid or its corresponding parseInt value if valid
+     * @return null if string is not valid or its corresponding parseInt value if
+     *         valid
      */
-    public Integer sanitizeStringAsInteger(String string){
+    public Integer sanitizeStringAsInteger(String string) {
         string = sanitizeString(string);
-        if(!isStringValidInteger(string)){
+        if (!isStringValidInteger(string)) {
             return null;
         }
         return Integer.parseInt(string);
@@ -136,11 +145,13 @@ public class ValidatorService {
 
     /**
      * sanitize a string
+     * 
      * @param string String to sanitize
-     * @return sanitized string value if string is valid, otherwise null (null or empty string input)
+     * @return sanitized string value if string is valid, otherwise null (null or
+     *         empty string input)
      */
-    public String sanitizeString(String string){
-        if(string == null){
+    public String sanitizeString(String string) {
+        if (string == null) {
             return null;
         }
         string = string.trim();
@@ -149,20 +160,25 @@ public class ValidatorService {
 
     /**
      * Checks if an input is one allowed for string comparisons (string & integer)
+     * 
      * @param input
      * @return True if validated
      */
     public boolean isValueStringCompatible(Object input) {
+        if(input == null){return false;}
         return (input instanceof Integer) || (input instanceof String);
     }
 
     /**
      * Checks if a String is a valid Integer format
+     * 
      * @param input
      * @return True if valid
      */
     public boolean isStringValidInteger(String string) {
-        if(string == null || string.isEmpty()){return false;}
+        if (string == null || string.isEmpty()) {
+            return false;
+        }
         try {
             Integer.parseInt(string);
             return true;
@@ -173,6 +189,7 @@ public class ValidatorService {
 
     /**
      * Validates if an input is not considered empty (null & empty string)
+     * 
      * @param input
      * @return True if input is not empty
      */
@@ -182,6 +199,7 @@ public class ValidatorService {
 
     /**
      * Validates if an input has a greater numerical value than the minimum allowed
+     * 
      * @param input
      * @return True if input is greater than the minimum
      */
@@ -194,6 +212,7 @@ public class ValidatorService {
 
     /**
      * Validates if an input has a lower numerical value than the maximum allowed
+     * 
      * @param input
      * @return True if input is lower than the minimum
      */
@@ -206,6 +225,7 @@ public class ValidatorService {
 
     /**
      * Validates if an input has more characters than the minimum allowed
+     * 
      * @param input
      * @return True if input is longer than the minimum
      */
@@ -218,6 +238,7 @@ public class ValidatorService {
 
     /**
      * Validates if an input has less characters than the maximum allowed
+     * 
      * @param input
      * @return True if input is short than the maximum
      */
@@ -230,12 +251,13 @@ public class ValidatorService {
 
     /**
      * Validates if an input is equal to an object contained in an array
-     * @param input Object to evaluate
+     * 
+     * @param input         Object to evaluate
      * @param allowedValues haystack
      * @return true if object is found in collection
      */
     public boolean isIncludedIn(Object input, Object[] allowedValues) {
-        if(input == null){
+        if (input == null) {
             return false;
         }
         for (Object allowedValue : allowedValues) {

--- a/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
@@ -10,13 +10,18 @@ import java.util.Set;
 import org.apache.tika.Tika;
 import org.springframework.stereotype.Service;
 
+import com.gregorybroche.imageresolver.Enums.ConstraintType;
+
 @Service
 public class ValidatorService {
-    private final List<String> allowedImageFormats = Arrays.asList("*.jpg", "*.jpeg", "*.png", "*.bmp", "*.webp", "*.avif");
-    private final List<String> allowedImageMimeTypes = Arrays.asList("image/jpeg", "image/png", "image/bmp", "image/webp", "image/avif");
+    private final List<String> allowedImageFormats = Arrays.asList("*.jpg", "*.jpeg", "*.png", "*.bmp", "*.webp",
+            "*.avif");
+    private final List<String> allowedImageMimeTypes = Arrays.asList("image/jpeg", "image/png", "image/bmp",
+            "image/webp", "image/avif");
 
     /**
-     * Validate that a file mime type complies with allowed mime types. 
+     * Validate that a file mime type complies with allowed mime types.
+     * 
      * @param file file to validate
      * @return true if file complies, false otherwise
      */
@@ -37,22 +42,25 @@ public class ValidatorService {
         return tika.detect(file);
     }
 
-    public Boolean isExtensionValid(String extension){
+    public Boolean isExtensionValid(String extension) {
         return getAllowedImageFormatsAsExtension().contains(extension);
     }
 
     /**
      * return List of allowed image formats with syntax like "*.webp"
+     * 
      * @return
      */
-    public List<String> getAllowedImageFormats(){
+    public List<String> getAllowedImageFormats() {
         return this.allowedImageFormats;
     }
+
     /**
      * return List of allowed image extension with syntax like "webp"
+     * 
      * @return
      */
-    public Set<String> getAllowedImageFormatsAsExtension(){
+    public Set<String> getAllowedImageFormatsAsExtension() {
         Set<String> allowedExtensions = new HashSet<String>();
         for (String format : allowedImageFormats) {
             allowedExtensions.add(format.replace("*.", ""));
@@ -61,11 +69,123 @@ public class ValidatorService {
     }
 
     /**
-     * return stringified list of allowed image formats
+     * returns stringified list of allowed image formats
+     * 
      * @return
      */
-    public String getAllowedImageFormatsAsString(){
+    public String getAllowedImageFormatsAsString() {
         String stringifiedAllowedFormat = String.join(", ", this.allowedImageFormats);
         return stringifiedAllowedFormat.replace("*", "");
     }
+
+    /**
+     * Validates if an input complies with a constraint
+     * @param input Input to validate, accepts Object to cover all case
+     * @param constraintValue Value of the constraint, accepts Object to cover all case
+     * @param constraintType Type of the constraint based on an enum
+     * @return True if input is compliant with the constraint
+     */
+    public boolean isConstraintValidated(Object input, Object constraintValue, ConstraintType constraintType) {
+        boolean isConstraintValid = false;
+        switch (constraintType) {
+            case REQUIRED:
+                isConstraintValid = isNotEmpty(input);
+                break;
+
+            case GREATER_THAN:
+                isConstraintValid = isGreaterThan(input, (Integer) constraintValue);
+                break;
+
+            case LESS_THAN:
+                isConstraintValid = isLessThan(input, (Integer) constraintValue);
+                break;
+
+            case LONGER_THAN:
+                isConstraintValid = isLongerThan(input, (Integer) constraintValue);
+                break;
+
+            case SHORTER_THAN:
+                isConstraintValid = isShorterThan(input, (Integer) constraintValue);
+                break;
+
+            default:
+                break;
+        }
+        return isConstraintValid;
+    }
+
+    /**
+     * Validates if an input is one allowed for string comparisons (string & integer)
+     * @param input
+     * @return True if validated
+     */
+    public boolean isValueStringCompatible(Object input) {
+        return (input instanceof Integer) || (input instanceof String);
+    }
+
+    /**
+     * Validates if an input is not considered empty (null & empty string)
+     * @param input
+     * @return True if input is not empty
+     */
+    public boolean isNotEmpty(Object input) {
+        return input != null && input.toString() != "";
+    }
+
+    /**
+     * Validates if an input has a greater numerical value than the minimum allowed
+     * @param input
+     * @return True if input is greater than the minimum
+     */
+    public boolean isGreaterThan(Object input, Integer min) {
+        if (!(input instanceof Integer)) {
+            return false;
+        }
+        return (Integer) input >= min;
+    }
+
+    /**
+     * Validates if an input has a lower numerical value than the maximum allowed
+     * @param input
+     * @return True if input is lower than the minimum
+     */
+    public boolean isLessThan(Object input, Integer max) {
+        if (!(input instanceof Integer)) {
+            return false;
+        }
+        return (Integer) input <= max;
+    }
+
+    /**
+     * Validates if an input has more characters than the minimum allowed
+     * @param input
+     * @return True if input is longer than the minimum
+     */
+    public boolean isLongerThan(Object input, Integer minLen) {
+        if (!isValueStringCompatible(input)) {
+            return false;
+        }
+        return input.toString().length() >= minLen;
+    }
+
+    /**
+     * Validates if an input has less characters than the maximum allowed
+     * @param input
+     * @return True if input is short than the maximum
+     */
+    public boolean isShorterThan(Object input, Integer maxLen) {
+        if (!isValueStringCompatible(input)) {
+            return false;
+        }
+        return input.toString().length() <= maxLen;
+    }
+
+    // public boolean isIncludedIn(Object input, Object[] allowedValues) {
+    //     for (Object allowedValue : allowedValues) {
+    //         if (input.equals(allowedValue)) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
 }

--- a/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
@@ -10,7 +10,6 @@ import java.util.Set;
 import org.apache.tika.Tika;
 import org.springframework.stereotype.Service;
 
-import com.gregorybroche.imageresolver.Enums.ConstraintType;
 import com.gregorybroche.imageresolver.classes.InputConstraint;
 import com.gregorybroche.imageresolver.classes.ValidationResponse;
 
@@ -123,12 +122,53 @@ public class ValidatorService {
     }
 
     /**
-     * Validates if an input is one allowed for string comparisons (string & integer)
+     * Sanitize and parses a string as an integer
+     * @param string String to parse
+     * @return null if string is not valid or its corresponding parseInt value if valid
+     */
+    public Integer sanitizeStringAsInteger(String string){
+        string = sanitizeString(string);
+        if(!isStringValidInteger(string)){
+            return null;
+        }
+        return Integer.parseInt(string);
+    }
+
+    /**
+     * sanitize a string
+     * @param string String to sanitize
+     * @return sanitized string value if string is valid, otherwise null (null or empty string input)
+     */
+    public String sanitizeString(String string){
+        if(string == null){
+            return null;
+        }
+        string = string.trim();
+        return string.length() > 0 ? string : null;
+    }
+
+    /**
+     * Checks if an input is one allowed for string comparisons (string & integer)
      * @param input
      * @return True if validated
      */
     public boolean isValueStringCompatible(Object input) {
         return (input instanceof Integer) || (input instanceof String);
+    }
+
+    /**
+     * Checks if a String is a valid Integer format
+     * @param input
+     * @return True if valid
+     */
+    public boolean isStringValidInteger(String string) {
+        if(string == null || string.isEmpty()){return false;}
+        try {
+            Integer.parseInt(string);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/ValidatorService.java
@@ -11,6 +11,8 @@ import org.apache.tika.Tika;
 import org.springframework.stereotype.Service;
 
 import com.gregorybroche.imageresolver.Enums.ConstraintType;
+import com.gregorybroche.imageresolver.classes.InputConstraint;
+import com.gregorybroche.imageresolver.classes.ValidationResponse;
 
 @Service
 public class ValidatorService {
@@ -85,37 +87,39 @@ public class ValidatorService {
      * @param constraintType Type of the constraint based on an enum
      * @return True if input is compliant with the constraint
      */
-    public boolean isConstraintValidated(Object input, Object constraintValue, ConstraintType constraintType) {
+    public ValidationResponse isConstraintValidated(Object input, InputConstraint inputConstraint) {
         boolean isConstraintValid = false;
-        switch (constraintType) {
+        switch (inputConstraint.getConstraintType()) {
             case REQUIRED:
                 isConstraintValid = isNotEmpty(input);
                 break;
 
             case GREATER_THAN:
-                isConstraintValid = isGreaterThan(input, (Integer) constraintValue);
+                isConstraintValid = isGreaterThan(input, (Integer) inputConstraint.getValue());
                 break;
 
             case LESS_THAN:
-                isConstraintValid = isLessThan(input, (Integer) constraintValue);
+                isConstraintValid = isLessThan(input, (Integer) inputConstraint.getValue());
                 break;
 
             case LONGER_THAN:
-                isConstraintValid = isLongerThan(input, (Integer) constraintValue);
+                isConstraintValid = isLongerThan(input, (Integer) inputConstraint.getValue());
                 break;
 
             case SHORTER_THAN:
-                isConstraintValid = isShorterThan(input, (Integer) constraintValue);
+                isConstraintValid = isShorterThan(input, (Integer) inputConstraint.getValue());
                 break;
 
             case INCLUDED_IN:
-                isConstraintValid = isIncludedIn(input, (Object[]) constraintValue);
+                isConstraintValid = isIncludedIn(input, (Object[]) inputConstraint.getValue());
                 break;
 
             default:
                 break;
         }
-        return isConstraintValid;
+        return isConstraintValid
+            ? new ValidationResponse(true, null, null)
+            : new ValidationResponse(false, null, inputConstraint.getErrorMessage());
     }
 
     /**

--- a/src/main/java/com/gregorybroche/imageresolver/views/main.fxml
+++ b/src/main/java/com/gregorybroche/imageresolver/views/main.fxml
@@ -36,7 +36,7 @@
                         <VBox fx:id="templateContainer" spacing="10.0" />
                      </content>
                   </ScrollPane>
-                  <Button fx:id="createTemplateButton" layoutX="234.0" layoutY="10.0" mnemonicParsing="false" onMouseClicked="#createTemplate" style="-fx-background-color: #5BB2E2;" text="Add" />
+                  <Button fx:id="createTemplateButton" layoutX="234.0" layoutY="10.0" mnemonicParsing="false" onMouseClicked="#openTemplateForm" style="-fx-background-color: #5BB2E2;" text="Add" />
                </children>
             </Pane>
          </children>

--- a/src/main/java/com/gregorybroche/imageresolver/views/main.fxml
+++ b/src/main/java/com/gregorybroche/imageresolver/views/main.fxml
@@ -21,8 +21,8 @@
                   </Pane>
                </children>
             </Pane>
-            <Button id="imageSelectorButton" fx:id="imageSelectorButton" layoutX="333.0" layoutY="515.0" mnemonicParsing="false" onMouseClicked="#selectImage" text="Select Image" />
-            <Button id="imageResolverButton" fx:id="imageResolverButton" layoutX="678.0" layoutY="515.0" mnemonicParsing="false" onMouseClicked="#resolveImage" text="Resolve" />
+            <Button id="imageSelectorButton" fx:id="imageSelectorButton" layoutX="333.0" layoutY="515.0" mnemonicParsing="false" onAction="#selectImage" text="Select Image" />
+            <Button id="imageResolverButton" fx:id="imageResolverButton" layoutX="678.0" layoutY="515.0" mnemonicParsing="false" onAction="#resolveImage" text="Resolve" />
          </children>
       </Pane>
       <Pane id="controlWrapper" layoutX="770.0" layoutY="50.0" prefHeight="615.0" prefWidth="300.0">
@@ -36,7 +36,7 @@
                         <VBox fx:id="templateContainer" spacing="10.0" />
                      </content>
                   </ScrollPane>
-                  <Button fx:id="createTemplateButton" layoutX="234.0" layoutY="10.0" mnemonicParsing="false" onMouseClicked="#openTemplateForm" style="-fx-background-color: #5BB2E2;" text="Add" />
+                  <Button fx:id="createTemplateButton" layoutX="234.0" layoutY="10.0" mnemonicParsing="false" onAction="#openTemplateForm" style="-fx-background-color: #5BB2E2;" text="Add" />
                </children>
             </Pane>
          </children>

--- a/src/main/java/com/gregorybroche/imageresolver/views/templateComponent.fxml
+++ b/src/main/java/com/gregorybroche/imageresolver/views/templateComponent.fxml
@@ -26,8 +26,8 @@
                         <TableColumn fx:id="formatColumn" prefWidth="60.0" resizable="false" sortable="false" text="Format" />
                     </columns>
                 </TableView>
-                <Button fx:id="templateEditButton" layoutX="80.0" layoutY="160.0" mnemonicParsing="false" onMouseClicked="#editTemplate" prefHeight="25.0" prefWidth="75.0" text="Edit" />
-                <Button fx:id="templateDeleteButton" layoutX="175.0" layoutY="160.0" mnemonicParsing="false" onMouseClicked="#deleteTemplate" prefHeight="25.0" prefWidth="75.0" style="-fx-background-color: red;" text="Delete" />
+                <Button fx:id="templateEditButton" layoutX="80.0" layoutY="160.0" mnemonicParsing="false" onAction="#editTemplate" prefHeight="25.0" prefWidth="75.0" text="Edit" />
+                <Button fx:id="templateDeleteButton" layoutX="175.0" layoutY="160.0" mnemonicParsing="false" onAction="#deleteTemplate" prefHeight="25.0" prefWidth="75.0" style="-fx-background-color: red;" text="Delete" />
             </children>
         </Pane>
 </HBox>

--- a/src/main/java/com/gregorybroche/imageresolver/views/templateForm.fxml
+++ b/src/main/java/com/gregorybroche/imageresolver/views/templateForm.fxml
@@ -7,43 +7,51 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.VBox?>
-
+<?import javafx.scene.text.Text?>
 
 <VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1">
    <children>
-      <Pane prefHeight="300.0" prefWidth="500.0" style="-fx-background-color: #D9D9D9;">
+      <Pane prefHeight="400.0" prefWidth="500.0" style="-fx-background-color: #D9D9D9;">
          <children>
-            <Pane layoutX="15.0" layoutY="5.0" prefHeight="33.0" prefWidth="471.0">
+            <Pane layoutX="15.0" layoutY="14.0" prefHeight="65.0" prefWidth="471.0">
                <children>
                   <TextField fx:id="InputTemplateName" layoutX="250.0" layoutY="3.0" />
                   <Label fx:id="templateFormTitleLabel" layoutX="140.0" layoutY="8.0" text="ADD TEMPLATE" />
+                  <Text fx:id="InputTemplateNameError" fill="#cd2828" layoutX="164.0" layoutY="46.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur Template name" />
                </children>
             </Pane>
-            <Pane layoutX="15.0" layoutY="40.0" prefHeight="80.0" prefWidth="470.0">
+            <Pane layoutX="15.0" layoutY="80.0" prefHeight="105.0" prefWidth="470.0">
                <children>
-                  <Label layoutX="-1.0" layoutY="6.0" text="Name" />
-                  <Label layoutY="40.0" text="Prefix" />
-                  <Label layoutX="235.0" layoutY="40.0" text="Suffix" />
-                  <TextField fx:id="InputFileBaseName" layoutX="45.0" layoutY="2.0" />
-                  <TextField fx:id="InputFilePrefix" layoutX="45.0" layoutY="35.0" />
-                  <TextField fx:id="InputFileSuffix" layoutX="280.0" layoutY="35.0" />
+                  <Label layoutY="12.0" text="Name" />
+                  <Label layoutX="1.0" layoutY="46.0" text="Prefix" />
+                  <Label layoutX="1.0" layoutY="78.0" text="Suffix" />
+                  <TextField fx:id="InputFileBaseName" layoutX="46.0" layoutY="8.0" />
+                  <TextField fx:id="InputFilePrefix" layoutX="46.0" layoutY="41.0" />
+                  <TextField fx:id="InputFileSuffix" layoutX="46.0" layoutY="73.0" />
+                  <Text fx:id="InputFileBaseNameError" fill="#cd2828" layoutX="211.0" layoutY="25.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur name" />
+                  <Text fx:id="InputFilePrefixError" fill="#cd2828" layoutX="211.0" layoutY="60.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur prefix" />
+                  <Text fx:id="InputFileSuffixError" fill="#cd2828" layoutX="211.0" layoutY="90.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur suffix" />
                </children>
             </Pane>
-            <Pane layoutX="15.0" layoutY="120.0" prefHeight="130.0" prefWidth="470.0">
+            <Pane layoutX="15.0" layoutY="185.0" prefHeight="160.0" prefWidth="470.0">
                <children>
                   <CheckBox fx:id="CheckboxMaintainRatio" layoutY="5.0" mnemonicParsing="false" text="Preserve image ratio" />
-                  <Label layoutX="-1.0" layoutY="48.0" text="Width" />
-                  <TextField fx:id="inputWidth" layoutX="45.0" layoutY="44.0" />
-                  <Label layoutX="235.0" layoutY="48.0" text="Height" />
-                  <TextField fx:id="inputHeight" layoutX="281.0" layoutY="44.0" />
-                  <Label layoutX="-1.0" layoutY="94.0" text="Res" />
-                  <TextField fx:id="inputResolution" layoutX="45.0" layoutY="90.0" prefHeight="25.0" prefWidth="101.0" />
-                  <Label layoutX="235.0" layoutY="94.0" text="Format" />
-                  <ChoiceBox fx:id="selectFormat" layoutX="280.0" layoutY="90.0" prefWidth="150.0" />
-                  <Label layoutX="146.0" layoutY="94.0" text="px/inc" />
+                  <Label layoutY="36.0" text="Width" />
+                  <TextField fx:id="inputWidth" layoutX="46.0" layoutY="32.0" />
+                  <Label layoutX="-1.0" layoutY="67.0" text="Height" />
+                  <TextField fx:id="inputHeight" layoutX="45.0" layoutY="63.0" />
+                  <Label layoutX="-1.0" layoutY="133.0" text="Res" />
+                  <TextField fx:id="inputResolution" layoutX="45.0" layoutY="129.0" prefHeight="25.0" prefWidth="101.0" />
+                  <Label layoutY="100.0" text="Format" />
+                  <ChoiceBox fx:id="selectFormat" layoutX="45.0" layoutY="96.0" prefWidth="150.0" />
+                  <Label layoutX="146.0" layoutY="133.0" text="px/inc" />
+                  <Text fx:id="inputWidthError" fill="#cd2828" layoutX="210.0" layoutY="49.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur width" />
+                  <Text fx:id="inputHeightError" fill="#cd2828" layoutX="210.0" layoutY="80.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur height" />
+                  <Text fx:id="selectFormatError" fill="#cd2828" layoutX="210.0" layoutY="113.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur format" />
+                  <Text fx:id="inputResolutionError" fill="#cd2828" layoutX="210.0" layoutY="146.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur resolution" />
                </children>
             </Pane>
-            <Pane layoutX="15.0" layoutY="250.0" prefHeight="50.0" prefWidth="470.0">
+            <Pane layoutX="15.0" layoutY="345.0" prefHeight="50.0" prefWidth="470.0">
                <children>
                   <Button fx:id="buttonSave" layoutX="355.0" layoutY="13.0" mnemonicParsing="false" prefHeight="25.0" prefWidth="75.0" text="Save" />
                   <Button fx:id="buttonCancel" layoutX="255.0" layoutY="13.0" mnemonicParsing="false" prefHeight="25.0" prefWidth="75.0" text="Cancel" />

--- a/src/main/java/com/gregorybroche/imageresolver/views/templateForm.fxml
+++ b/src/main/java/com/gregorybroche/imageresolver/views/templateForm.fxml
@@ -54,7 +54,7 @@
             <Pane layoutX="15.0" layoutY="345.0" prefHeight="50.0" prefWidth="470.0">
                <children>
                   <Button fx:id="buttonSave" layoutX="355.0" layoutY="13.0" mnemonicParsing="false" prefHeight="25.0" prefWidth="75.0" text="Save" onAction="#handleSubmit" disable="true" />
-                  <Button fx:id="buttonCancel" layoutX="255.0" layoutY="13.0" mnemonicParsing="false" prefHeight="25.0" prefWidth="75.0" text="Cancel" />
+                  <Button fx:id="buttonCancel" layoutX="255.0" layoutY="13.0" mnemonicParsing="false" prefHeight="25.0" prefWidth="75.0" text="Cancel" onAction="#cancelForm" />
                </children>
             </Pane>
          </children>

--- a/src/main/java/com/gregorybroche/imageresolver/views/templateForm.fxml
+++ b/src/main/java/com/gregorybroche/imageresolver/views/templateForm.fxml
@@ -9,15 +9,15 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Text?>
 
-<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1">
+<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.gregorybroche.imageresolver.controller.TemplateFormController">
    <children>
       <Pane prefHeight="400.0" prefWidth="500.0" style="-fx-background-color: #D9D9D9;">
          <children>
             <Pane layoutX="15.0" layoutY="14.0" prefHeight="65.0" prefWidth="471.0">
                <children>
-                  <TextField fx:id="InputTemplateName" layoutX="250.0" layoutY="3.0" />
+                  <TextField fx:id="inputTemplateName" layoutX="250.0" layoutY="3.0" onKeyTyped="#validateTemplateNameChange" />
                   <Label fx:id="templateFormTitleLabel" layoutX="140.0" layoutY="8.0" text="ADD TEMPLATE" />
-                  <Text fx:id="InputTemplateNameError" fill="#cd2828" layoutX="164.0" layoutY="46.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur Template name" />
+                  <Text fx:id="inputTemplateNameError" fill="#cd2828" layoutX="164.0" layoutY="46.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur Template name" />
                </children>
             </Pane>
             <Pane layoutX="15.0" layoutY="80.0" prefHeight="105.0" prefWidth="470.0">
@@ -25,25 +25,25 @@
                   <Label layoutY="12.0" text="Name" />
                   <Label layoutX="1.0" layoutY="46.0" text="Prefix" />
                   <Label layoutX="1.0" layoutY="78.0" text="Suffix" />
-                  <TextField fx:id="InputFileBaseName" layoutX="46.0" layoutY="8.0" />
-                  <TextField fx:id="InputFilePrefix" layoutX="46.0" layoutY="41.0" />
-                  <TextField fx:id="InputFileSuffix" layoutX="46.0" layoutY="73.0" />
-                  <Text fx:id="InputFileBaseNameError" fill="#cd2828" layoutX="211.0" layoutY="25.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur name" />
-                  <Text fx:id="InputFilePrefixError" fill="#cd2828" layoutX="211.0" layoutY="60.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur prefix" />
-                  <Text fx:id="InputFileSuffixError" fill="#cd2828" layoutX="211.0" layoutY="90.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur suffix" />
+                  <TextField fx:id="inputFileBaseName" layoutX="46.0" layoutY="8.0" onKeyTyped="#validateImageBaseNameChange" />
+                  <TextField fx:id="inputFilePrefix" layoutX="46.0" layoutY="41.0" onKeyTyped="#validateImagePrefixChange" />
+                  <TextField fx:id="inputFileSuffix" layoutX="46.0" layoutY="73.0" onKeyTyped="#validateImageSuffixChange" />
+                  <Text fx:id="inputFileBaseNameError" fill="#cd2828" layoutX="211.0" layoutY="25.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur name" />
+                  <Text fx:id="inputFilePrefixError" fill="#cd2828" layoutX="211.0" layoutY="60.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur prefix" />
+                  <Text fx:id="inputFileSuffixError" fill="#cd2828" layoutX="211.0" layoutY="90.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur suffix" />
                </children>
             </Pane>
             <Pane layoutX="15.0" layoutY="185.0" prefHeight="160.0" prefWidth="470.0">
                <children>
-                  <CheckBox fx:id="CheckboxMaintainRatio" layoutY="5.0" mnemonicParsing="false" text="Preserve image ratio" />
+                  <CheckBox fx:id="checkboxMaintainRatio" layoutY="5.0" mnemonicParsing="false" text="Preserve image ratio" />
                   <Label layoutY="36.0" text="Width" />
-                  <TextField fx:id="inputWidth" layoutX="46.0" layoutY="32.0" />
+                  <TextField fx:id="inputWidth" layoutX="46.0" layoutY="32.0" onKeyTyped="#validateWidthChange" />
                   <Label layoutX="-1.0" layoutY="67.0" text="Height" />
-                  <TextField fx:id="inputHeight" layoutX="45.0" layoutY="63.0" />
+                  <TextField fx:id="inputHeight" layoutX="45.0" layoutY="63.0" onKeyTyped="#validateHeightChange" />
                   <Label layoutX="-1.0" layoutY="133.0" text="Res" />
-                  <TextField fx:id="inputResolution" layoutX="45.0" layoutY="129.0" prefHeight="25.0" prefWidth="101.0" />
+                  <TextField fx:id="inputResolution" layoutX="45.0" layoutY="129.0" onKeyTyped="#validateResolutionChange" prefHeight="25.0" prefWidth="101.0" />
                   <Label layoutY="100.0" text="Format" />
-                  <ChoiceBox fx:id="selectFormat" layoutX="45.0" layoutY="96.0" prefWidth="150.0" />
+                  <ChoiceBox fx:id="selectFormat" layoutX="45.0" layoutY="96.0" prefWidth="150.0" onAction="#validateFormatChange"/>
                   <Label layoutX="146.0" layoutY="133.0" text="px/inc" />
                   <Text fx:id="inputWidthError" fill="#cd2828" layoutX="210.0" layoutY="49.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur width" />
                   <Text fx:id="inputHeightError" fill="#cd2828" layoutX="210.0" layoutY="80.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur height" />

--- a/src/main/java/com/gregorybroche/imageresolver/views/templateForm.fxml
+++ b/src/main/java/com/gregorybroche/imageresolver/views/templateForm.fxml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.ChoiceBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.Pane?>
+<?import javafx.scene.layout.VBox?>
+
+
+<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1">
+   <children>
+      <Pane prefHeight="300.0" prefWidth="500.0" style="-fx-background-color: #D9D9D9;">
+         <children>
+            <Pane layoutX="15.0" layoutY="5.0" prefHeight="33.0" prefWidth="471.0">
+               <children>
+                  <TextField fx:id="InputTemplateName" layoutX="250.0" layoutY="3.0" />
+                  <Label fx:id="templateFormTitleLabel" layoutX="140.0" layoutY="8.0" text="ADD TEMPLATE" />
+               </children>
+            </Pane>
+            <Pane layoutX="15.0" layoutY="40.0" prefHeight="80.0" prefWidth="470.0">
+               <children>
+                  <Label layoutX="-1.0" layoutY="6.0" text="Name" />
+                  <Label layoutY="40.0" text="Prefix" />
+                  <Label layoutX="235.0" layoutY="40.0" text="Suffix" />
+                  <TextField fx:id="InputFileBaseName" layoutX="45.0" layoutY="2.0" />
+                  <TextField fx:id="InputFilePrefix" layoutX="45.0" layoutY="35.0" />
+                  <TextField fx:id="InputFileSuffix" layoutX="280.0" layoutY="35.0" />
+               </children>
+            </Pane>
+            <Pane layoutX="15.0" layoutY="120.0" prefHeight="130.0" prefWidth="470.0">
+               <children>
+                  <CheckBox fx:id="CheckboxMaintainRatio" layoutY="5.0" mnemonicParsing="false" text="Preserve image ratio" />
+                  <Label layoutX="-1.0" layoutY="48.0" text="Width" />
+                  <TextField fx:id="inputWidth" layoutX="45.0" layoutY="44.0" />
+                  <Label layoutX="235.0" layoutY="48.0" text="Height" />
+                  <TextField fx:id="inputHeight" layoutX="281.0" layoutY="44.0" />
+                  <Label layoutX="-1.0" layoutY="94.0" text="Res" />
+                  <TextField fx:id="inputResolution" layoutX="45.0" layoutY="90.0" prefHeight="25.0" prefWidth="101.0" />
+                  <Label layoutX="235.0" layoutY="94.0" text="Format" />
+                  <ChoiceBox fx:id="selectFormat" layoutX="280.0" layoutY="90.0" prefWidth="150.0" />
+                  <Label layoutX="146.0" layoutY="94.0" text="px/inc" />
+               </children>
+            </Pane>
+            <Pane layoutX="15.0" layoutY="250.0" prefHeight="50.0" prefWidth="470.0">
+               <children>
+                  <Button fx:id="buttonSave" layoutX="355.0" layoutY="13.0" mnemonicParsing="false" prefHeight="25.0" prefWidth="75.0" text="Save" />
+                  <Button fx:id="buttonCancel" layoutX="255.0" layoutY="13.0" mnemonicParsing="false" prefHeight="25.0" prefWidth="75.0" text="Cancel" />
+               </children>
+            </Pane>
+         </children>
+      </Pane>
+   </children>
+</VBox>

--- a/src/main/java/com/gregorybroche/imageresolver/views/templateForm.fxml
+++ b/src/main/java/com/gregorybroche/imageresolver/views/templateForm.fxml
@@ -17,7 +17,7 @@
                <children>
                   <TextField fx:id="inputTemplateName" layoutX="250.0" layoutY="3.0" onKeyTyped="#validateTemplateNameChange" />
                   <Label fx:id="templateFormTitleLabel" layoutX="140.0" layoutY="8.0" text="ADD TEMPLATE" />
-                  <Text fx:id="inputTemplateNameError" fill="#cd2828" layoutX="164.0" layoutY="46.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur Template name" />
+                  <Text fx:id="inputTemplateNameError" fill="#cd2828" layoutX="164.0" layoutY="46.0" strokeType="OUTSIDE" strokeWidth="0.0" visible="false" text="" />
                </children>
             </Pane>
             <Pane layoutX="15.0" layoutY="80.0" prefHeight="105.0" prefWidth="470.0">
@@ -28,9 +28,9 @@
                   <TextField fx:id="inputFileBaseName" layoutX="46.0" layoutY="8.0" onKeyTyped="#validateImageBaseNameChange" />
                   <TextField fx:id="inputFilePrefix" layoutX="46.0" layoutY="41.0" onKeyTyped="#validateImagePrefixChange" />
                   <TextField fx:id="inputFileSuffix" layoutX="46.0" layoutY="73.0" onKeyTyped="#validateImageSuffixChange" />
-                  <Text fx:id="inputFileBaseNameError" fill="#cd2828" layoutX="211.0" layoutY="25.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur name" />
-                  <Text fx:id="inputFilePrefixError" fill="#cd2828" layoutX="211.0" layoutY="60.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur prefix" />
-                  <Text fx:id="inputFileSuffixError" fill="#cd2828" layoutX="211.0" layoutY="90.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur suffix" />
+                  <Text fx:id="inputFileBaseNameError" fill="#cd2828" layoutX="211.0" layoutY="25.0" strokeType="OUTSIDE" strokeWidth="0.0" visible="false" text="" />
+                  <Text fx:id="inputFilePrefixError" fill="#cd2828" layoutX="211.0" layoutY="60.0" strokeType="OUTSIDE" strokeWidth="0.0" visible="false" text="" />
+                  <Text fx:id="inputFileSuffixError" fill="#cd2828" layoutX="211.0" layoutY="90.0" strokeType="OUTSIDE" strokeWidth="0.0" visible="false" text="" />
                </children>
             </Pane>
             <Pane layoutX="15.0" layoutY="185.0" prefHeight="160.0" prefWidth="470.0">
@@ -45,15 +45,15 @@
                   <Label layoutY="100.0" text="Format" />
                   <ChoiceBox fx:id="selectFormat" layoutX="45.0" layoutY="96.0" prefWidth="150.0" onAction="#validateFormatChange"/>
                   <Label layoutX="146.0" layoutY="133.0" text="px/inc" />
-                  <Text fx:id="inputWidthError" fill="#cd2828" layoutX="210.0" layoutY="49.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur width" />
-                  <Text fx:id="inputHeightError" fill="#cd2828" layoutX="210.0" layoutY="80.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur height" />
-                  <Text fx:id="selectFormatError" fill="#cd2828" layoutX="210.0" layoutY="113.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur format" />
-                  <Text fx:id="inputResolutionError" fill="#cd2828" layoutX="210.0" layoutY="146.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Erreur resolution" />
+                  <Text fx:id="inputWidthError" fill="#cd2828" layoutX="210.0" layoutY="49.0" strokeType="OUTSIDE" strokeWidth="0.0" visible="false" text="" />
+                  <Text fx:id="inputHeightError" fill="#cd2828" layoutX="210.0" layoutY="80.0" strokeType="OUTSIDE" strokeWidth="0.0" visible="false" text="" />
+                  <Text fx:id="selectFormatError" fill="#cd2828" layoutX="210.0" layoutY="113.0" strokeType="OUTSIDE" strokeWidth="0.0" visible="false" text="" />
+                  <Text fx:id="inputResolutionError" fill="#cd2828" layoutX="210.0" layoutY="146.0" strokeType="OUTSIDE" strokeWidth="0.0" visible="false" text="" />
                </children>
             </Pane>
             <Pane layoutX="15.0" layoutY="345.0" prefHeight="50.0" prefWidth="470.0">
                <children>
-                  <Button fx:id="buttonSave" layoutX="355.0" layoutY="13.0" mnemonicParsing="false" prefHeight="25.0" prefWidth="75.0" text="Save" disable="true" />
+                  <Button fx:id="buttonSave" layoutX="355.0" layoutY="13.0" mnemonicParsing="false" prefHeight="25.0" prefWidth="75.0" text="Save" onAction="#handleSubmit" disable="true" />
                   <Button fx:id="buttonCancel" layoutX="255.0" layoutY="13.0" mnemonicParsing="false" prefHeight="25.0" prefWidth="75.0" text="Cancel" />
                </children>
             </Pane>

--- a/src/main/java/com/gregorybroche/imageresolver/views/templateForm.fxml
+++ b/src/main/java/com/gregorybroche/imageresolver/views/templateForm.fxml
@@ -53,7 +53,7 @@
             </Pane>
             <Pane layoutX="15.0" layoutY="345.0" prefHeight="50.0" prefWidth="470.0">
                <children>
-                  <Button fx:id="buttonSave" layoutX="355.0" layoutY="13.0" mnemonicParsing="false" prefHeight="25.0" prefWidth="75.0" text="Save" />
+                  <Button fx:id="buttonSave" layoutX="355.0" layoutY="13.0" mnemonicParsing="false" prefHeight="25.0" prefWidth="75.0" text="Save" disable="true" />
                   <Button fx:id="buttonCancel" layoutX="255.0" layoutY="13.0" mnemonicParsing="false" prefHeight="25.0" prefWidth="75.0" text="Cancel" />
                </children>
             </Pane>

--- a/src/test/java/com/gregorybroche/imageresolver/classes/PresetTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/classes/PresetTest.java
@@ -1,0 +1,56 @@
+package com.gregorybroche.imageresolver.classes;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PresetTest {
+    private ImageTemplate template1;
+    private ImageTemplate template2;
+    private ImageTemplate template3;
+
+    @BeforeEach
+    void setUp() {
+        this.template1= new ImageTemplate(
+            "template1",
+            400,
+            200,
+            72,
+            "test-",
+            "image1", 
+            null, 
+            "jpg");
+
+        this.template2= new ImageTemplate(
+            "template2",
+            600,
+            300,
+            90,
+            "test-",
+            "image2", 
+            null, 
+            "jpg");
+
+        this.template3= new ImageTemplate(
+            "template3",
+            1920,
+            1080,
+            72,
+            "test-",
+            "image3", 
+            "-large", 
+            "png");
+    }
+
+
+    @Test
+    void testAddTemplate_addingOneTemplate_ShouldHaveOneElementInList() {
+        Preset testPreset = new Preset("testPreset");
+        testPreset.addTemplate(template1);
+        assertTrue(testPreset.getTemplates().size() == 1, "Should have one element");
+        assertTrue(testPreset.getTemplates().get(0).getTemplateName().equals("template1"), "Should retrieve name of added template");
+    }
+
+    
+}

--- a/src/test/java/com/gregorybroche/imageresolver/classes/PresetTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/classes/PresetTest.java
@@ -2,6 +2,8 @@ package com.gregorybroche.imageresolver.classes;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -46,7 +48,7 @@ public class PresetTest {
 
     @Test
     void testAddTemplate_addingOneTemplate_ShouldHaveOneElementInList() {
-        Preset testPreset = new Preset("testPreset");
+        Preset testPreset = new Preset("testPreset", new ArrayList<ImageTemplate>());
         testPreset.addTemplate(template1);
         assertTrue(testPreset.getTemplates().size() == 1, "Should have one element");
         assertTrue(testPreset.getTemplates().get(0).getTemplateName().equals("template1"), "Should retrieve name of added template");

--- a/src/test/java/com/gregorybroche/imageresolver/classes/PresetTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/classes/PresetTest.java
@@ -53,6 +53,18 @@ public class PresetTest {
         assertTrue(testPreset.getTemplates().size() == 1, "Should have one element");
         assertTrue(testPreset.getTemplates().get(0).getTemplateName().equals("template1"), "Should retrieve name of added template");
     }
+    @Test
+
+    void testAddTemplate_addingThreeSuccessiveTemplate_ShouldHaveThreeElementsInList() {
+        Preset testPreset = new Preset("testPreset", new ArrayList<ImageTemplate>());
+        testPreset.addTemplate(template1);
+        testPreset.addTemplate(template2);
+        testPreset.addTemplate(template3);
+        assertTrue(testPreset.getTemplates().size() == 3, "Should have one element");
+        assertTrue(testPreset.getTemplates().get(0).getTemplateName().equals("template1"), "Should retrieve name of first added template");
+        assertTrue(testPreset.getTemplates().get(1).getTemplateName().equals("template2"), "Should retrieve name of second added template");
+        assertTrue(testPreset.getTemplates().get(2).getTemplateName().equals("template3"), "Should retrieve name of third added template");
+    }
 
     
 }

--- a/src/test/java/com/gregorybroche/imageresolver/classes/ValidationResponseTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/classes/ValidationResponseTest.java
@@ -1,0 +1,18 @@
+package com.gregorybroche.imageresolver.classes;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class ValidationResponseTest {
+
+
+    @Test
+        void constructor_passingNullParameters_ShouldConstructAndIsNullPropertyGettersReturnTrue() {
+        ValidationResponse validationResponse = new ValidationResponse(false, null, null);
+        assertFalse(validationResponse.getIsSuccess());
+        assertTrue(validationResponse.isDataNull());
+        assertTrue(validationResponse.isMessageNull());
+    }
+}

--- a/src/test/java/com/gregorybroche/imageresolver/service/FileHandlerServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/FileHandlerServiceTest.java
@@ -72,7 +72,6 @@ public class FileHandlerServiceTest {
         ReflectionTestUtils.setField(fileHandlerService, "appTempDirectoryPath", testTempDirectory);
 
         testImageBufferedContent = imageEditorService.createTestImageContent();
-
     }
 
     void tearDownTestFolder(Path TestFolderToDestroy) {

--- a/src/test/java/com/gregorybroche/imageresolver/service/PresetManagementServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/PresetManagementServiceTest.java
@@ -1,6 +1,7 @@
 package com.gregorybroche.imageresolver.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -112,6 +113,57 @@ public class PresetManagementServiceTest {
             assertEquals(nameFirstTemplateOfSecondSetPreset, templateTest3.getTemplateName());
             assertEquals(nameSecondTemplateOfSecondSetPreset, templateTest4.getTemplateName());
 
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    void addTemplateToPreset_addingValidTemplate_shouldReturnTrue(){
+        try {
+            List<Preset> presetList = new ArrayList<Preset>();
+            List<ImageTemplate> presetTestContent = new ArrayList<ImageTemplate>();
+            Preset preset = new Preset("presetTest", presetTestContent);
+            presetList.add(preset);
+            presetManagementService.setPresets(presetList);
+        
+            boolean result = presetManagementService.addTemplateToPreset(templateTest1, "presetTest");
+            assertTrue(result);
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    void addTemplateToPreset_addingNull_shouldReturnFalse(){
+        try {
+            List<Preset> presetList = new ArrayList<Preset>();
+            List<ImageTemplate> presetTestContent = new ArrayList<ImageTemplate>();
+            Preset preset = new Preset("presetTest", presetTestContent);
+            presetList.add(preset);
+            presetManagementService.setPresets(presetList);
+        
+            boolean result = presetManagementService.addTemplateToPreset(null, "presetTest");
+            assertFalse(result);
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    void addTemplateToPreset_addingTemplateWithNameCollision_shouldReturnFalse(){
+        try {
+            List<Preset> presetList = new ArrayList<Preset>();
+            List<ImageTemplate> presetTestContent = new ArrayList<ImageTemplate>();
+            Preset preset = new Preset("presetTest", presetTestContent);
+            presetList.add(preset);
+            presetManagementService.setPresets(presetList);
+        
+            boolean resultFirstAddition = presetManagementService.addTemplateToPreset(templateTest1, "presetTest");
+            assertTrue(resultFirstAddition);
+
+            boolean resultCollision = presetManagementService.addTemplateToPreset(templateTest1, "presetTest");
+            assertFalse(resultCollision);
         } catch (Exception e) {
             fail();
         }

--- a/src/test/java/com/gregorybroche/imageresolver/service/PresetManagementServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/PresetManagementServiceTest.java
@@ -1,0 +1,119 @@
+package com.gregorybroche.imageresolver.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.gregorybroche.imageresolver.classes.ImageTemplate;
+import com.gregorybroche.imageresolver.classes.Preset;
+
+public class PresetManagementServiceTest {
+    private PresetManagementService presetManagementService;
+    private ImageTemplate templateTest1 = new ImageTemplate(
+        "templateTest1",
+        1920,
+        1080,
+        96,
+        "XL",
+        "test-image",
+        null,
+        "jpg"
+        );
+
+    private ImageTemplate templateTest2 = new ImageTemplate(
+        "templateTest2",
+        1080,
+        720,
+        96,
+        "L",
+        "test-image",
+        null,
+        "jpg"
+        );
+
+    private ImageTemplate templateTest3 = new ImageTemplate(
+        "templateTest3",
+        720,
+        480,
+        96,
+        "M",
+        "test-image",
+        null,
+        "jpg"
+        );
+
+    private ImageTemplate templateTest4 = new ImageTemplate(
+        "templateTest4",
+        360,
+        240,
+        96,
+        "S",
+        "test-image",
+        null,
+        "jpg"
+        );
+
+    public PresetManagementServiceTest(){
+        this.presetManagementService = new PresetManagementService();
+    }
+
+    @Test
+    void setPresets_inputListIsEmpty_shouldReturnEmptyMap(){
+        try {
+            List<Preset> emptyPresetList = new ArrayList<Preset>();
+            presetManagementService.setPresets(emptyPresetList);
+            Map<String, Preset> retrievedPresetList = presetManagementService.getPresets();
+            assertTrue(retrievedPresetList.isEmpty());
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    void setPresets_inputListWithTwoPresets_shouldAddBothPresets(){
+        try {
+            List<ImageTemplate> preset1Content = new ArrayList<ImageTemplate>();
+            preset1Content.add(templateTest1);
+            preset1Content.add(templateTest2);
+            preset1Content.add(templateTest3);
+            preset1Content.add(templateTest4);
+
+            List<ImageTemplate> preset2Content = new ArrayList<ImageTemplate>();
+            preset2Content.add(templateTest3);
+            preset2Content.add(templateTest4);
+
+            Preset preset1 = new Preset("presetTest1", preset1Content);
+            Preset preset2 = new Preset("presetTest2", preset2Content);
+
+            List<Preset> presetList = new ArrayList<Preset>();
+            presetList.add(preset1);
+            presetList.add(preset2);
+
+            presetManagementService.setPresets(presetList);
+            String nameFirstTemplateOfFirstSetPreset = presetManagementService.getPresetFromKey("presetTest1").getTemplates().get(0).getTemplateName();
+            String nameSecondTemplateOfFirstSetPreset = presetManagementService.getPresetFromKey("presetTest1").getTemplates().get(1).getTemplateName();
+            String nameThirdTemplateOfFirstSetPreset = presetManagementService.getPresetFromKey("presetTest1").getTemplates().get(2).getTemplateName();
+            String nameFourthTemplateOfFirstSetPreset = presetManagementService.getPresetFromKey("presetTest1").getTemplates().get(3).getTemplateName();
+
+            String nameFirstTemplateOfSecondSetPreset = presetManagementService.getPresetFromKey("presetTest2").getTemplates().get(0).getTemplateName();
+            String nameSecondTemplateOfSecondSetPreset = presetManagementService.getPresetFromKey("presetTest2").getTemplates().get(1).getTemplateName();
+            
+            assertEquals(nameFirstTemplateOfFirstSetPreset, templateTest1.getTemplateName());
+            assertEquals(nameSecondTemplateOfFirstSetPreset, templateTest2.getTemplateName());
+            assertEquals(nameThirdTemplateOfFirstSetPreset, templateTest3.getTemplateName());
+            assertEquals(nameFourthTemplateOfFirstSetPreset, templateTest4.getTemplateName());
+
+            assertEquals(nameFirstTemplateOfSecondSetPreset, templateTest3.getTemplateName());
+            assertEquals(nameSecondTemplateOfSecondSetPreset, templateTest4.getTemplateName());
+
+        } catch (Exception e) {
+            fail();
+        }
+    }
+}

--- a/src/test/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorServiceTest.java
@@ -19,7 +19,8 @@ public class TemplateFormValidatorServiceTest {
     @BeforeEach
     void setUp(){
         ValidatorService validatorService = new ValidatorService();
-        templateSubmitterService = new TemplateFormValidatorService(validatorService);
+        UserDialogService userDialogService = new UserDialogService(validatorService);
+        templateSubmitterService = new TemplateFormValidatorService(validatorService, userDialogService);
     }
 
     @Test

--- a/src/test/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorServiceTest.java
@@ -13,19 +13,19 @@ import org.junit.jupiter.api.Test;
 import com.gregorybroche.imageresolver.classes.InputConstraint;
 import com.gregorybroche.imageresolver.classes.ValidationResponse;
 
-public class TemplateSubmitterServiceTest {
-    private TemplateSubmitterService templateSubmitterService;
+public class TemplateFormValidatorServiceTest {
+    private TemplateFormValidatorService templateSubmitterService;
 
     @BeforeEach
     void setUp(){
         ValidatorService validatorService = new ValidatorService();
-        templateSubmitterService = new TemplateSubmitterService(validatorService);
+        templateSubmitterService = new TemplateFormValidatorService(validatorService);
     }
 
     @Test
     void generateTemplateNameConstraints_shouldReturnAdequateConstraints() {
         try {
-            Method generateTemplateNameConstraintsMethod = TemplateSubmitterService.class.getDeclaredMethod("generateTemplateNameConstraints");
+            Method generateTemplateNameConstraintsMethod = TemplateFormValidatorService.class.getDeclaredMethod("generateTemplateNameConstraints");
             generateTemplateNameConstraintsMethod.setAccessible(true);
             InputConstraint[] templateNameConstraints = (InputConstraint[]) generateTemplateNameConstraintsMethod.invoke(this.templateSubmitterService);
             assertEquals(templateNameConstraints[0].getConstraintName(), "requiredTemplateName");

--- a/src/test/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/TemplateFormValidatorServiceTest.java
@@ -63,7 +63,7 @@ public class TemplateFormValidatorServiceTest {
     @Test
     void validateInput_widthIsLessThanAllowed_shouldReturnValidationResponseFalseWithErrorWidthLessThanAllowed(){
         this.templateSubmitterService.setAllConstraints();
-        int value = 5;
+        String value = "5";
         String expectedMessage = "The width must be an int greater than";
         ValidationResponse testResponse = this.templateSubmitterService.validateInput(value, "width");
         assertFalse(testResponse.getIsSuccess());
@@ -73,7 +73,7 @@ public class TemplateFormValidatorServiceTest {
     @Test
     void validateInput_widthIsMoreThanAllowed_shouldReturnValidationResponseFalseWithErrorWidthGreaterThanAllowed(){
         this.templateSubmitterService.setAllConstraints();
-        int value = 11000;
+        String value = "11000";
         String expectedMessage = "The width must be an int less than";
         ValidationResponse testResponse = this.templateSubmitterService.validateInput(value, "width");
         assertFalse(testResponse.getIsSuccess());

--- a/src/test/java/com/gregorybroche/imageresolver/service/TemplateSubmitterServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/TemplateSubmitterServiceTest.java
@@ -1,6 +1,8 @@
 package com.gregorybroche.imageresolver.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Method;
@@ -9,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.gregorybroche.imageresolver.classes.InputConstraint;
+import com.gregorybroche.imageresolver.classes.ValidationResponse;
 
 public class TemplateSubmitterServiceTest {
     private TemplateSubmitterService templateSubmitterService;
@@ -46,5 +49,33 @@ public class TemplateSubmitterServiceTest {
         assertEquals(prefixConstraints[0].getConstraintName(), "requiredImagePrefix");
         InputConstraint[] formatConstraints = templateSubmitterService.getFormConstraints().get("format");
         assertEquals(formatConstraints[0].getConstraintName(), "requiredFormat");
+    }
+
+    @Test
+    void validateInput_widthIsNull_shouldReturnValidationResponseFalseWithErrorWidthIsRequired(){
+        this.templateSubmitterService.setAllConstraints();
+        ValidationResponse testResponse = this.templateSubmitterService.validateInput(null, "width");
+        assertFalse(testResponse.getIsSuccess());
+        assertEquals(testResponse.getMessage(), "The width is required");
+    }
+
+    @Test
+    void validateInput_widthIsLessThanAllowed_shouldReturnValidationResponseFalseWithErrorWidthLessThanAllowed(){
+        this.templateSubmitterService.setAllConstraints();
+        int value = 5;
+        String expectedMessage = "The width must be an int greater than";
+        ValidationResponse testResponse = this.templateSubmitterService.validateInput(value, "width");
+        assertFalse(testResponse.getIsSuccess());
+        assertTrue(testResponse.getMessage().contains(expectedMessage));
+    }
+
+    @Test
+    void validateInput_widthIsMoreThanAllowed_shouldReturnValidationResponseFalseWithErrorWidthGreaterThanAllowed(){
+        this.templateSubmitterService.setAllConstraints();
+        int value = 11000;
+        String expectedMessage = "The width must be an int less than";
+        ValidationResponse testResponse = this.templateSubmitterService.validateInput(value, "width");
+        assertFalse(testResponse.getIsSuccess());
+        assertTrue(testResponse.getMessage().contains(expectedMessage));
     }
 }

--- a/src/test/java/com/gregorybroche/imageresolver/service/TemplateSubmitterServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/TemplateSubmitterServiceTest.java
@@ -1,0 +1,34 @@
+package com.gregorybroche.imageresolver.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.gregorybroche.imageresolver.classes.InputConstraint;
+
+public class TemplateSubmitterServiceTest {
+    private TemplateSubmitterService templateSubmitterService;
+
+    @BeforeEach
+    void setUp(){
+        ValidatorService validatorService = new ValidatorService();
+        templateSubmitterService = new TemplateSubmitterService(validatorService);
+    }
+
+    @Test
+    void generateTemplateNameConstraints_shouldReturnAdequateConstraints() {
+        try {
+            Method generateTemplateNameConstraintsMethod = TemplateSubmitterService.class.getDeclaredMethod("generateTemplateNameConstraints");
+            generateTemplateNameConstraintsMethod.setAccessible(true);
+            InputConstraint[] templateNameConstraints = (InputConstraint[]) generateTemplateNameConstraintsMethod.invoke(this.templateSubmitterService);
+            assertEquals(templateNameConstraints[0].getConstraintName(), "requiredTemplateName");
+        } catch (Exception e) {
+            fail("Exception triggered " + e.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/gregorybroche/imageresolver/service/TemplateSubmitterServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/TemplateSubmitterServiceTest.java
@@ -1,7 +1,6 @@
 package com.gregorybroche.imageresolver.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Method;
@@ -30,5 +29,22 @@ public class TemplateSubmitterServiceTest {
         } catch (Exception e) {
             fail("Exception triggered " + e.getMessage());
         }
+    }
+
+    @Test
+    void setAllConstraints_TemplateSubmitterServiceFormConstraints_shouldContainAllConstraintsNames() {
+        this.templateSubmitterService.setAllConstraints();
+        InputConstraint[] templateNameConstraints = templateSubmitterService.getFormConstraints().get("templateName");
+        assertEquals(templateNameConstraints[0].getConstraintName(), "requiredTemplateName");
+        InputConstraint[] widthConstraints = templateSubmitterService.getFormConstraints().get("width");
+        assertEquals(widthConstraints[0].getConstraintName(), "requiredWidth");
+        InputConstraint[] heightConstraints = templateSubmitterService.getFormConstraints().get("height");
+        assertEquals(heightConstraints[0].getConstraintName(), "requiredHeight");
+        InputConstraint[] resolutionConstraints = templateSubmitterService.getFormConstraints().get("resolution");
+        assertEquals(resolutionConstraints[0].getConstraintName(), "requiredResolution");
+        InputConstraint[] prefixConstraints = templateSubmitterService.getFormConstraints().get("prefix");
+        assertEquals(prefixConstraints[0].getConstraintName(), "requiredImagePrefix");
+        InputConstraint[] formatConstraints = templateSubmitterService.getFormConstraints().get("format");
+        assertEquals(formatConstraints[0].getConstraintName(), "requiredFormat");
     }
 }

--- a/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
@@ -15,6 +15,10 @@ import org.junit.jupiter.api.io.TempDir;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.Assert;
 
+import com.gregorybroche.imageresolver.Enums.ConstraintType;
+import com.gregorybroche.imageresolver.classes.InputConstraint;
+import com.gregorybroche.imageresolver.classes.ValidationResponse;
+
 public class ValidatorServiceTest {
     private final List<String> testAllowedImageFormats = Arrays.asList("*.jpg", "*.jpeg", "*.png", "*.bmp", "*.webp", "*.avif");
     private final String expectedStringifiedValue = ".jpg, .jpeg, .png, .bmp, .webp, .avif";
@@ -423,16 +427,39 @@ public class ValidatorServiceTest {
     @Test
     void isIncludedIn_valueIsInArrayUsingRealConstraint_ShouldReturnTrue() {
         String value = "webp";
-        TemplateSubmitterService templateSubmitterService = new TemplateSubmitterService(this.validatorService);
+        TemplateSubmitterService templateSubmitterService = new TemplateSubmitterService(validatorService);
         assertTrue(validatorService.isIncludedIn(value, templateSubmitterService.getAllowedFormats()));
     }
 
-    // public boolean isIncludedIn(Object input, Object[] allowedValues) {
-    //     for (Object allowedValue : allowedValues) {
-    //         if (input.equals(allowedValue)) {
-    //             return true;
-    //         }
-    //     }
-    //     return false;
-    // }
+    /* ***** isConstraintValidated ***** */
+
+    @Test
+    void isConstraintValidated_constraintIsNotValidated_ShouldReturnValidationResponseFalseNullErrorMessage() {
+        int value = 479;
+        InputConstraint testConstraint = new InputConstraint(
+            "testConstraint",
+            ConstraintType.GREATER_THAN,
+            480,
+            "test has failed"
+            );
+        ValidationResponse testResult = validatorService.isConstraintValidated(value, testConstraint);
+        assertFalse(testResult.getIsSuccess());
+        assertNull(testResult.getData());
+        assertEquals(testResult.getMessage(), "test has failed");
+    }
+
+    @Test
+    void isConstraintValidated_constraintIsValidated_ShouldReturnValidationResponseTrueNullNull() {
+        int value = 480;
+        InputConstraint testConstraint = new InputConstraint(
+            "testConstraint",
+            ConstraintType.GREATER_THAN,
+            480,
+            "test has passed"
+            );
+        ValidationResponse testResult = validatorService.isConstraintValidated(value, testConstraint);
+        assertTrue(testResult.getIsSuccess());
+        assertNull(testResult.getData());
+        assertNull(testResult.getMessage());
+    }
 }

--- a/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
@@ -367,4 +367,72 @@ public class ValidatorServiceTest {
         Integer maxLen = 4;
         assertFalse(validatorService.isShorterThan(value, maxLen));
     }
+
+    /* ***** isIncludedIn ***** */
+
+    @Test
+    void isIncludedIn_valueAsNullAndArrayIsEmpty_ShouldReturnFalse() {
+        String value = null;
+        String[] haystack = new String[5];
+        assertFalse(validatorService.isIncludedIn(value, haystack));
+    }
+
+    @Test
+    void isIncludedIn_valueAndArrayTypesAreMismatched_ShouldReturnFalse() {
+        int value = 3;
+        String[] haystack = new String[5];
+        haystack[0] = "1";
+        haystack[1] = "2";
+        haystack[2] = "3";
+        haystack[3] = "4";
+        haystack[4] = "5";
+        assertFalse(validatorService.isIncludedIn(value, haystack));
+    }
+
+    @Test
+    void isIncludedIn_valueIsNotInArray_ShouldReturnFalse() {
+        String value = "tiff";
+        String[] haystack = new String[5];
+        haystack[0] = "jpg";
+        haystack[1] = "png";
+        haystack[2] = "webp";
+        haystack[3] = "jpeg";
+        haystack[4] = "avif";
+        assertFalse(validatorService.isIncludedIn(value, haystack));
+    }
+
+    @Test
+    void isIncludedIn_valueIsInArray_ShouldReturnTrue() {
+        String value = "webp";
+        String[] haystack = new String[5];
+        haystack[0] = "jpg";
+        haystack[1] = "png";
+        haystack[2] = "webp";
+        haystack[3] = "jpeg";
+        haystack[4] = "avif";
+        assertTrue(validatorService.isIncludedIn(value, haystack));
+    }
+
+    @Test
+    void isIncludedIn_valueIsNotInArrayUsingRealConstraint_ShouldReturnFalse() {
+        String value = "tiff";
+        TemplateSubmitterService templateSubmitterService = new TemplateSubmitterService(this.validatorService);
+        assertFalse(validatorService.isIncludedIn(value, templateSubmitterService.getAllowedFormats()));
+    }
+
+    @Test
+    void isIncludedIn_valueIsInArrayUsingRealConstraint_ShouldReturnTrue() {
+        String value = "webp";
+        TemplateSubmitterService templateSubmitterService = new TemplateSubmitterService(this.validatorService);
+        assertTrue(validatorService.isIncludedIn(value, templateSubmitterService.getAllowedFormats()));
+    }
+
+    // public boolean isIncludedIn(Object input, Object[] allowedValues) {
+    //     for (Object allowedValue : allowedValues) {
+    //         if (input.equals(allowedValue)) {
+    //             return true;
+    //         }
+    //     }
+    //     return false;
+    // }
 }

--- a/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
@@ -419,14 +419,14 @@ public class ValidatorServiceTest {
     @Test
     void isIncludedIn_valueIsNotInArrayUsingRealConstraint_ShouldReturnFalse() {
         String value = "tiff";
-        TemplateSubmitterService templateSubmitterService = new TemplateSubmitterService(this.validatorService);
+        TemplateFormValidatorService templateSubmitterService = new TemplateFormValidatorService(this.validatorService);
         assertFalse(validatorService.isIncludedIn(value, templateSubmitterService.getAllowedFormats()));
     }
 
     @Test
     void isIncludedIn_valueIsInArrayUsingRealConstraint_ShouldReturnTrue() {
         String value = "webp";
-        TemplateSubmitterService templateSubmitterService = new TemplateSubmitterService(validatorService);
+        TemplateFormValidatorService templateSubmitterService = new TemplateFormValidatorService(validatorService);
         assertTrue(validatorService.isIncludedIn(value, templateSubmitterService.getAllowedFormats()));
     }
 

--- a/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
@@ -436,7 +436,7 @@ public class ValidatorServiceTest {
     @Test
     void isConstraintValidated_constraintIsNotValidated_ShouldReturnValidationResponseFalseNullErrorMessage() {
         try {
-            int value = 479;
+            String value = "479";
             InputConstraint testConstraint = new InputConstraint(
                 "testConstraint",
                 ConstraintType.GREATER_THAN,
@@ -456,7 +456,7 @@ public class ValidatorServiceTest {
     @Test
     void isConstraintValidated_constraintIsValidated_ShouldReturnValidationResponseTrueNullNull() {
         try {
-            int value = 480;
+            String value = "480";
             InputConstraint testConstraint = new InputConstraint(
                 "testConstraint",
                 ConstraintType.GREATER_THAN,

--- a/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
@@ -24,6 +24,8 @@ public class ValidatorServiceTest {
     private final List<String> testAllowedImageMimeTypes = Arrays.asList("image/jpeg", "image/png", "image/bmp", "image/webp", "image/avif");
     ValidatorService validatorService;
     ImageEditorService imageEditorService;
+    UserDialogService userDialogService;
+    TemplateFormValidatorService templateSubmitterService;
     BufferedImage testImageBufferedContent;
 
     @TempDir
@@ -32,8 +34,9 @@ public class ValidatorServiceTest {
     @BeforeEach
     void setUp(){
         validatorService = new ValidatorService(); 
-        UserDialogService userDialogService = new UserDialogService(validatorService);
+        userDialogService = new UserDialogService(validatorService);
         imageEditorService = new ImageEditorService(validatorService, userDialogService);
+        templateSubmitterService = new TemplateFormValidatorService(this.validatorService, userDialogService);
         ReflectionTestUtils.setField(validatorService, "allowedImageMimeTypes", testAllowedImageMimeTypes);
         ReflectionTestUtils.setField(validatorService, "allowedImageFormats", testAllowedImageFormats);
     }
@@ -419,14 +422,12 @@ public class ValidatorServiceTest {
     @Test
     void isIncludedIn_valueIsNotInArrayUsingRealConstraint_ShouldReturnFalse() {
         String value = "tiff";
-        TemplateFormValidatorService templateSubmitterService = new TemplateFormValidatorService(this.validatorService);
         assertFalse(validatorService.isIncludedIn(value, templateSubmitterService.getAllowedFormats()));
     }
 
     @Test
     void isIncludedIn_valueIsInArrayUsingRealConstraint_ShouldReturnTrue() {
         String value = "webp";
-        TemplateFormValidatorService templateSubmitterService = new TemplateFormValidatorService(validatorService);
         assertTrue(validatorService.isIncludedIn(value, templateSubmitterService.getAllowedFormats()));
     }
 
@@ -434,31 +435,41 @@ public class ValidatorServiceTest {
 
     @Test
     void isConstraintValidated_constraintIsNotValidated_ShouldReturnValidationResponseFalseNullErrorMessage() {
-        int value = 479;
-        InputConstraint testConstraint = new InputConstraint(
-            "testConstraint",
-            ConstraintType.GREATER_THAN,
-            480,
-            "test has failed"
-            );
-        ValidationResponse testResult = validatorService.isConstraintValidated(value, testConstraint);
-        assertFalse(testResult.getIsSuccess());
-        assertNull(testResult.getData());
-        assertEquals(testResult.getMessage(), "test has failed");
+        try {
+            int value = 479;
+            InputConstraint testConstraint = new InputConstraint(
+                "testConstraint",
+                ConstraintType.GREATER_THAN,
+                480,
+                "test has failed"
+                );
+            ValidationResponse testResult = validatorService.isConstraintValidated(value, testConstraint);
+            assertFalse(testResult.getIsSuccess());
+            assertNull(testResult.getData());
+            assertEquals(testResult.getMessage(), "test has failed");
+        } catch (Exception e) {
+            fail();
+        }
+
     }
 
     @Test
     void isConstraintValidated_constraintIsValidated_ShouldReturnValidationResponseTrueNullNull() {
-        int value = 480;
-        InputConstraint testConstraint = new InputConstraint(
-            "testConstraint",
-            ConstraintType.GREATER_THAN,
-            480,
-            "test has passed"
-            );
-        ValidationResponse testResult = validatorService.isConstraintValidated(value, testConstraint);
-        assertTrue(testResult.getIsSuccess());
-        assertNull(testResult.getData());
-        assertNull(testResult.getMessage());
+        try {
+            int value = 480;
+            InputConstraint testConstraint = new InputConstraint(
+                "testConstraint",
+                ConstraintType.GREATER_THAN,
+                480,
+                "test has passed"
+                );
+            ValidationResponse testResult = validatorService.isConstraintValidated(value, testConstraint);
+            assertTrue(testResult.getIsSuccess());
+            assertNull(testResult.getData());
+            assertNull(testResult.getMessage());
+        } catch (Exception e) {
+            fail();
+        }
+
     }
 }

--- a/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.util.Assert;
 
 import com.gregorybroche.imageresolver.Enums.ConstraintType;
 import com.gregorybroche.imageresolver.classes.InputConstraint;

--- a/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.Assert;
 
 public class ValidatorServiceTest {
     private final List<String> testAllowedImageFormats = Arrays.asList("*.jpg", "*.jpeg", "*.png", "*.bmp", "*.webp", "*.avif");
@@ -32,7 +33,6 @@ public class ValidatorServiceTest {
         imageEditorService = new ImageEditorService(validatorService, userDialogService);
         ReflectionTestUtils.setField(validatorService, "allowedImageMimeTypes", testAllowedImageMimeTypes);
         ReflectionTestUtils.setField(validatorService, "allowedImageFormats", testAllowedImageFormats);
-        testImageBufferedContent = imageEditorService.createTestImageContent();
     }
 
     /*
@@ -71,6 +71,7 @@ public class ValidatorServiceTest {
     @Test
     void isFileValidImageFormat_fileAsPNG_ShouldReturnTrue() {
         try {
+            testImageBufferedContent = imageEditorService.createTestImageContent();
             File testPNGFile = tempDir.resolve("testImage.png").toFile();
             imageEditorService.createPNGImage(testImageBufferedContent, testPNGFile);
             assertTrue(validatorService.isFileValidImageFormat(testPNGFile));
@@ -82,6 +83,7 @@ public class ValidatorServiceTest {
     @Test
     void isFileValidImageFormat_fileAsJPG_ShouldReturnTrue() {
         try {
+            testImageBufferedContent = imageEditorService.createTestImageContent();
             File testJPGFile = tempDir.resolve("testImage.jpg").toFile();
             imageEditorService.createPNGImage(testImageBufferedContent, testJPGFile);
             assertTrue(validatorService.isFileValidImageFormat(testJPGFile));
@@ -93,6 +95,7 @@ public class ValidatorServiceTest {
     @Test
     void isFileValidImageFormat_fileAsJPEG_ShouldReturnTrue() {
         try {
+            testImageBufferedContent = imageEditorService.createTestImageContent();
             File testJPEGFile = tempDir.resolve("testImage.jpeg").toFile();
             imageEditorService.createPNGImage(testImageBufferedContent, testJPEGFile);
             assertTrue(validatorService.isFileValidImageFormat(testJPEGFile));
@@ -104,6 +107,7 @@ public class ValidatorServiceTest {
     @Test
     void isFileValidImageFormat_fileAsBMP_ShouldReturnTrue() {
         try {
+            testImageBufferedContent = imageEditorService.createTestImageContent();
             File testBMPFile = tempDir.resolve("testImage.bmp").toFile();
             imageEditorService.createPNGImage(testImageBufferedContent, testBMPFile);
             assertTrue(validatorService.isFileValidImageFormat(testBMPFile));
@@ -114,6 +118,7 @@ public class ValidatorServiceTest {
     @Test
     void isFileValidImageFormat_fileAsWEBP_ShouldReturnTrue() {
         try {
+            testImageBufferedContent = imageEditorService.createTestImageContent();
             File testWEBPFile = tempDir.resolve("testImage.webp").toFile();
             imageEditorService.createPNGImage(testImageBufferedContent, testWEBPFile);
             assertTrue(validatorService.isFileValidImageFormat(testWEBPFile));
@@ -131,5 +136,235 @@ public class ValidatorServiceTest {
         } catch (Exception e) {
             fail("Exception triggered " + e.getMessage());
         }
+    }
+
+    /*
+    * ***** TESTING INPUT RELATED METHODS ***** 
+    */
+
+    /* ***** isValueStringCompatible ***** */
+
+    @Test
+    void isValueStringCompatible_valueAsString_ShouldReturnTrue() {
+        String value = "test";
+        assertTrue(validatorService.isValueStringCompatible(value));
+    }
+
+    @Test
+    void isValueStringCompatible_valueAsEmptyString_ShouldReturnTrue() {
+        String value = "";
+        assertTrue(validatorService.isValueStringCompatible(value));
+    }
+
+    @Test
+    void isValueStringCompatible_valueAsNullString_ShouldReturnFalse() {
+        String value = null;
+        assertFalse(validatorService.isValueStringCompatible(value));
+    }
+
+    @Test
+    void isValueStringCompatible_valueAsInteger_ShouldReturnTrue() {
+        Integer value = 5;
+        assertTrue(validatorService.isValueStringCompatible(value));
+    }
+
+    @Test
+    void isValueStringCompatible_valueAsNullInteger_ShouldReturnFalse() {
+        Integer value = null;
+        assertFalse(validatorService.isValueStringCompatible(value));
+    }
+
+    @Test
+    void isValueStringCompatible_valueAsObject_ShouldReturnFalse() {
+        Object value = new Object();
+        assertFalse(validatorService.isValueStringCompatible(value));
+    }
+
+        /* ***** isNotEmpty ***** */
+
+    @Test
+    void isNotEmpty_valueAs0_ShouldReturnTrue() {
+        Integer value = 0;
+        assertTrue(validatorService.isNotEmpty(value));
+    }
+
+    @Test
+    void isNotEmpty_valueAsNonEmptyString_ShouldReturnTrue() {
+        String value = "test";
+        assertTrue(validatorService.isNotEmpty(value));
+    }
+
+    @Test
+    void isNotEmpty_valueAsEmptyString_ShouldReturnFalse() {
+        String value = "";
+        assertFalse(validatorService.isNotEmpty(value));
+    }
+
+    @Test
+    void isNotEmpty_valueAsNull_ShouldReturnFalse() {
+        Object value = null;
+        assertFalse(validatorService.isNotEmpty(value));
+    }
+
+    /* ***** isGreaterThan ***** */
+
+    @Test
+    void isGreaterThan_valueAsNull_ShouldReturnFalse() {
+        Integer value = null;
+        Integer min = 5;
+        assertFalse(validatorService.isGreaterThan(value, min));
+    }
+
+    @Test
+    void isGreaterThan_valueBelowMin_ShouldReturnFalse() {
+        Integer value = 2;
+        Integer min = 5;
+        assertFalse(validatorService.isGreaterThan(value, min));
+    }
+
+    @Test
+    void isGreaterThan_valueAboveMin_ShouldReturnTrue() {
+        Integer value = 8;
+        Integer min = 5;
+        assertTrue(validatorService.isGreaterThan(value, min));
+    }
+
+    @Test
+    void isGreaterThan_valueAboveMinNegativeInt_ShouldReturnTrue() {
+        Integer value = -3;
+        Integer min = -5;
+        assertTrue(validatorService.isGreaterThan(value, min));
+    }
+
+    @Test
+    void isGreaterThan_valueAsGreaterString_ShouldReturnFalse() {
+        String value = "8";
+        Integer min = 5;
+        assertFalse(validatorService.isGreaterThan(value, min));
+    }
+
+    /* ***** isLessThan ***** */
+
+    @Test
+    void isLessThan_valueAsNull_ShouldReturnFalse() {
+        Integer value = null;
+        Integer max = 5;
+        assertFalse(validatorService.isLessThan(value, max));
+    }
+
+    @Test
+    void isLessThan_valueBelowMin_ShouldReturnTrue() {
+        Integer value = 2;
+        Integer max = 5;
+        assertTrue(validatorService.isLessThan(value, max));
+    }
+
+    @Test
+    void isLessThan_valueAboveMin_ShouldReturnFalse() {
+        Integer value = 8;
+        Integer max = 5;
+        assertFalse(validatorService.isLessThan(value, max));
+    }
+
+    @Test
+    void isLessThan_valueAboveMinNegativeInt_ShouldReturnFalse() {
+        Integer value = -3;
+        Integer max = -5;
+        assertFalse(validatorService.isLessThan(value, max));
+    }
+    
+    @Test
+    void isLessThan_valueAsLesserString_ShouldReturnFalse() {
+        String value = "2";
+        Integer max = 5;
+        assertFalse(validatorService.isGreaterThan(value, max));
+    }
+    
+    /* ***** isLongerThan ***** */
+
+    @Test
+    void isLongerThan_valueAsNull_ShouldReturnFalse() {
+        String value = null;
+        Integer minLen = 0;
+        assertFalse(validatorService.isLongerThan(value, minLen));
+    }
+
+    @Test
+    void isLongerThan_valueAsNeitherStringNorInteger_ShouldReturnFalse() {
+        List<String> value = this.testAllowedImageFormats;
+        Integer minLen = 0;
+        assertFalse(validatorService.isLongerThan(value, minLen));
+    }
+
+    @Test
+    void isLongerThan_valueAsShorterString_ShouldReturnFalse() {
+        String value = "short";
+        Integer minLen = 10;
+        assertFalse(validatorService.isLongerThan(value, minLen));
+    }
+
+    @Test
+    void isLongerThan_valueAsLongerString_ShouldReturnTrue() {
+        String value = "longer string";
+        Integer minLen = 10;
+        assertTrue(validatorService.isLongerThan(value, minLen));
+    }
+
+    @Test
+    void isLongerThan_valueAsShorterInteger_ShouldReturnFalse() {
+        Integer value = 49;
+        Integer minLen = 10;
+        assertFalse(validatorService.isLongerThan(value, minLen));
+    }
+
+    @Test
+    void isLongerThan_valueAsLongerInteger_ShouldReturnTrue() {
+        Integer value = 58426;
+        Integer minLen = 4;
+        assertTrue(validatorService.isLongerThan(value, minLen));
+    }
+    
+    /* ***** isShorterThan ***** */
+
+    @Test
+    void isShorterThan_valueAsNull_ShouldReturnFalse() {
+        String value = null;
+        Integer maxLen = 0;
+        assertFalse(validatorService.isShorterThan(value, maxLen));
+    }
+
+    @Test
+    void isShorterThan_valueAsNeitherStringNorInteger_ShouldReturnFalse() {
+        List<String> value = this.testAllowedImageFormats;
+        Integer maxLen = 0;
+        assertFalse(validatorService.isShorterThan(value, maxLen));
+    }
+
+    @Test
+    void isShorterThan_valueAsShorterString_ShouldReturnTrue() {
+        String value = "short";
+        Integer maxLen = 10;
+        assertTrue(validatorService.isShorterThan(value, maxLen));
+    }
+
+    @Test
+    void isShorterThan_valueAsLongerString_ShouldReturnFalse() {
+        String value = "longer string";
+        Integer maxLen = 10;
+        assertFalse(validatorService.isShorterThan(value, maxLen));
+    }
+
+    @Test
+    void isShorterThan_valueAsShorterInteger_ShouldReturnTrue() {
+        Integer value = 49;
+        Integer maxLen = 10;
+        assertTrue(validatorService.isShorterThan(value, maxLen));
+    }
+
+    @Test
+    void isShorterThan_valueAsLongerInteger_ShouldReturnFalse() {
+        Integer value = 58426;
+        Integer maxLen = 4;
+        assertFalse(validatorService.isShorterThan(value, maxLen));
     }
 }


### PR DESCRIPTION
Added ability to add a new template to the currently managed preset with validation and feedback based on predefined constraints.
Adding a template triggers a refresh of the display of currently existing templates for the managed preset.

At this stage the maintain ratio of base image feature is not yet implement as the image is not yet used in this part. The idea would be to get the sizes of the image and forward the info to the modal template form window and use those to calculate one of the dimension if the user modify the input for the other dimension (example : calculate height if user changes width if that checkbox is cheked).

A quality of life feature to implement once the logic for managing the list of templates is done would be to sort the list before the display is triggered in order to have templates be ordered by decreasing width value.