### PR TITLE
15 implement editing a template inside of a preset

### DIFF
--- a/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
@@ -17,14 +17,16 @@ public class ImageTemplate {
     private String format = "jpg";
     private int defaultResolution = 90;
 
-    public ImageTemplate(String templateName,
-                        int width,
-                        int height,
-                        Integer resolution,
-                        String newImagePrefix,
-                        String newImageBaseName,
-                        String newImageSuffix,
-                        String format){
+    public ImageTemplate(
+        String templateName,
+        int width,
+        int height,
+        Integer resolution,
+        String newImagePrefix,
+        String newImageBaseName,
+        String newImageSuffix,
+        String format
+        ){
         setTemplateName(templateName);
         setWidth(width);
         setHeight(height);

--- a/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
@@ -117,7 +117,6 @@ public class ImageTemplate {
 
         } catch (IOException e) {
             System.err.println(e.getMessage());
-            e.printStackTrace();
             return null;
         }
     }

--- a/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
@@ -7,14 +7,14 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.layout.HBox;
 
 public class ImageTemplate {
-    private String templateName = "PlaceHolder name";
-    private int width = 600;
-    private int height = 400;
-    private int resolution = 72;
-    private String newImagePrefix = "pre-";
-    private String newImageBaseName = "test_editing";
-    private String newImageSuffix = "-post";
-    private String format = "jpg";
+    private String templateName;
+    private int width;
+    private int height;
+    private int resolution;
+    private String newImagePrefix;
+    private String newImageBaseName;
+    private String newImageSuffix;
+    private String format;
     private int defaultResolution = 90;
 
     public ImageTemplate(

--- a/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/ImageTemplate.java
@@ -1,7 +1,11 @@
 package com.gregorybroche.imageresolver.classes;
 
 import java.io.IOException;
+
+import org.springframework.context.ApplicationContext;
+
 import com.gregorybroche.imageresolver.controller.TemplateItemController;
+import com.gregorybroche.imageresolver.interfaces.TemplateEditFormSubmitListener;
 
 import javafx.fxml.FXMLLoader;
 import javafx.scene.layout.HBox;
@@ -101,18 +105,18 @@ public class ImageTemplate {
      * Creates and returns the FXML component view with data corresponding to this instance of ImageTemplate
      * @return
      */
-    public HBox createTemplateComponent(Integer indexInPreset) {
+    public HBox createTemplateComponent(Integer indexInPreset, ApplicationContext applicationContext, TemplateEditFormSubmitListener callbackOnEditAction){
         try {
             FXMLLoader loader = new FXMLLoader(getClass().getResource("../views/templateComponent.fxml"));
-            HBox templatePane = loader.load();
-
+            loader.setControllerFactory(applicationContext::getBean);
+            HBox templateHBox = loader.load();
             TemplateItemController controller = loader.getController();
-
             controller.setTemplateData(this, indexInPreset);
-
-            return templatePane;
+            controller.setEmitEditListener(callbackOnEditAction);
+            return templateHBox;
 
         } catch (IOException e) {
+            System.err.println(e.getMessage());
             e.printStackTrace();
             return null;
         }

--- a/src/main/java/com/gregorybroche/imageresolver/classes/InputConstraint.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/InputConstraint.java
@@ -3,9 +3,8 @@ package com.gregorybroche.imageresolver.classes;
 import com.gregorybroche.imageresolver.Enums.ConstraintType;
 
 /**
- * Class intended to by used to define constraints for user submitted inputs
+ * Class for defining constraints on user submitted inputs
  */
-
 public class InputConstraint {
     private String constraintName;
     private ConstraintType constraintType;

--- a/src/main/java/com/gregorybroche/imageresolver/classes/Preset.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/Preset.java
@@ -28,22 +28,46 @@ public class Preset {
         return this.templates;
     }
 
-    public boolean isTemplateNameAlreadyPresent(String name) {
-        for (ImageTemplate template : templates) {
-            if (template.getTemplateName().equals(name)){
+    public boolean isTemplateNameAlreadyPresent(String name, Integer excludedIndex) {
+        for (int i = 0; i < templates.size(); i++) {
+            if (templates.get(i).getTemplateName().equals(name) && (excludedIndex==null || i != excludedIndex)){
                 return true;
             }
+        }
+        for (ImageTemplate template : templates) {
+
         }
         return false;
     }
 
     public boolean addTemplate(ImageTemplate imageTemplate){
         try {
-            if(isTemplateNameAlreadyPresent(imageTemplate.getTemplateName())){
+            if(isTemplateNameAlreadyPresent(imageTemplate.getTemplateName(), null)){
                 return false;
             }
             this.templates.add(imageTemplate);
             return this.templates.getLast().getTemplateName().equals(imageTemplate.getTemplateName());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public boolean editTemplate(ImageTemplate newTemplateData, int indexOfPresetToReplace){
+        try {
+            if(isTemplateNameAlreadyPresent(newTemplateData.getTemplateName(), indexOfPresetToReplace)){
+                return false;
+            }
+            ImageTemplate templateToEdit = this.templates.get(indexOfPresetToReplace);
+
+            templateToEdit.setTemplateName(newTemplateData.getTemplateName());
+            templateToEdit.setNewImageBaseName(newTemplateData.getNewImageBaseName());
+            templateToEdit.setNewImagePrefix(newTemplateData.getNewImagePrefix());
+            templateToEdit.setNewImageSuffix(newTemplateData.getNewImageSuffix());
+            templateToEdit.setWidth(newTemplateData.getWidth());
+            templateToEdit.setHeight(newTemplateData.getHeight());
+            templateToEdit.setResolution(newTemplateData.getResolution());
+            templateToEdit.setFormat(newTemplateData.getFormat());
+            return true;
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/com/gregorybroche/imageresolver/classes/Preset.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/Preset.java
@@ -28,18 +28,27 @@ public class Preset {
         return this.templates;
     }
 
-    public boolean isTemplateNameAlreadyPresent(String name, Integer excludedIndex) {
+    /**
+     * checks if a name string already corresponds to an existing template name in the template list
+     * @param templateName string of the name to test
+     * @param excludedIndex use an index to ignore a specific template from the check, used in case of validating edit action with an unchanged
+     * template name
+     * @return true if a template matches the given string, otherwise false
+     */
+    public boolean isTemplateNameAlreadyPresent(String templateName, Integer excludedIndex) {
         for (int i = 0; i < templates.size(); i++) {
-            if (templates.get(i).getTemplateName().equals(name) && (excludedIndex==null || i != excludedIndex)){
+            if (templates.get(i).getTemplateName().equals(templateName) && (excludedIndex==null || i != excludedIndex)){
                 return true;
             }
-        }
-        for (ImageTemplate template : templates) {
-
         }
         return false;
     }
 
+    /**
+     * Adds a template to the list of templates
+     * @param imageTemplate
+     * @return true if adding was successful, otherwise false
+     */
     public boolean addTemplate(ImageTemplate imageTemplate){
         try {
             if(isTemplateNameAlreadyPresent(imageTemplate.getTemplateName(), null)){
@@ -52,12 +61,18 @@ public class Preset {
         }
     }
 
-    public boolean editTemplate(ImageTemplate newTemplateData, int indexOfPresetToReplace){
+    /**
+     * Edits a template using an other template's data
+     * @param newTemplateData
+     * @param indexOfTemplateToReplace index of template to edit in this preset's template list
+     * @return true if editing the template's properties was successful, otherwise false
+     */
+    public boolean editTemplate(ImageTemplate newTemplateData, int indexOfTemplateToReplace){
         try {
-            if(isTemplateNameAlreadyPresent(newTemplateData.getTemplateName(), indexOfPresetToReplace)){
+            if(isTemplateNameAlreadyPresent(newTemplateData.getTemplateName(), indexOfTemplateToReplace)){
                 return false;
             }
-            ImageTemplate templateToEdit = this.templates.get(indexOfPresetToReplace);
+            ImageTemplate templateToEdit = this.templates.get(indexOfTemplateToReplace);
 
             templateToEdit.setTemplateName(newTemplateData.getTemplateName());
             templateToEdit.setNewImageBaseName(newTemplateData.getNewImageBaseName());

--- a/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
@@ -31,6 +31,7 @@ import javafx.stage.Stage;
 
 @Component
 public class MainController {
+    private ApplicationContext applicationContext;
     private UserDialogService userDialogService;
     private FileHandlerService fileHandlerService;
     private ValidatorService validatorService;
@@ -51,6 +52,7 @@ public class MainController {
             PresetManagementService presetManagementService,
             TemplateFormService templateFormService
             ) {
+        this.applicationContext = applicationContext;
         this.userDialogService = userDialogService;
         this.fileHandlerService = fileHandlerService;
         this.validatorService = validatorService;
@@ -78,6 +80,7 @@ public class MainController {
     @FXML
     public void initialize() {
         presetManagementService.loadPresets();
+        displayLoadedTemplates();
     }
 
     @FXML
@@ -113,7 +116,7 @@ public class MainController {
     @FXML
     void openTemplateForm(ActionEvent event) {
         try {
-            Stage stage = templateFormService.createAddTemplateForm(newTemplate -> {
+            Stage stage = templateFormService.createTemplateForm(newTemplate -> {
                 addSubmittedTemplateToPreset(newTemplate);
             });
 
@@ -158,10 +161,19 @@ public class MainController {
 
     /**
      * adds a template to currently managed preset and refresh the template list display
+     * @param template template to add
+     */
+    private void addSubmittedTemplateToPreset(ImageTemplate submittedTemplate) {
+        presetManagementService.addTemplateToPreset(submittedTemplate, Selectedpreset);
+        displayLoadedTemplates();
+    }
+
+    /**
+     * edit a template and refresh the template list display
      * @param template display to add
      */
-    private void addSubmittedTemplateToPreset(ImageTemplate template) {
-        presetManagementService.addTemplateToPreset(template, Selectedpreset);
+    private void editTemplate(ImageTemplate submittedTemplate, int indexOfTemplateToEdit) {
+        presetManagementService.editTemplateOfPreset(submittedTemplate, indexOfTemplateToEdit, Selectedpreset);
         displayLoadedTemplates();
     }
 
@@ -172,7 +184,13 @@ public class MainController {
         List<ImageTemplate> templates = presetManagementService.getPresetFromKey(Selectedpreset).getTemplates();
         List<HBox> templateComponents = new ArrayList<HBox>();
         for (int i = 0; i < templates.size(); i++) {
-            templateComponents.add(templates.get(i).createTemplateComponent(i)) ;
+            templateComponents.add(templates.get(i).createTemplateComponent(
+                i,
+                applicationContext,
+                (submittedTemplateData, indexOfTemplateToEdit) -> {
+                editTemplate(submittedTemplateData, indexOfTemplateToEdit);
+            }
+            )) ;
         }
         templateContainer.getChildren().setAll(templateComponents);
     }

--- a/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
@@ -15,32 +15,29 @@ import com.gregorybroche.imageresolver.service.FileHandlerService;
 import com.gregorybroche.imageresolver.service.ImageEditorService;
 import com.gregorybroche.imageresolver.service.PresetManagementService;
 import com.gregorybroche.imageresolver.service.ResolverProcessorService;
+import com.gregorybroche.imageresolver.service.TemplateFormService;
 import com.gregorybroche.imageresolver.service.UserDialogService;
 import com.gregorybroche.imageresolver.service.ValidatorService;
 
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
-import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
-import javafx.scene.Parent;
-import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
-import javafx.stage.Modality;
 import javafx.stage.Stage;
 
 @Component
 public class MainController {
-    private ApplicationContext applicationContext;
     private UserDialogService userDialogService;
     private FileHandlerService fileHandlerService;
     private ValidatorService validatorService;
     private ImageEditorService imageEditorService;
     private ResolverProcessorService resolverProcessorService;
-    PresetManagementService presetManagementService;
+    private TemplateFormService templateFormService;
+    private PresetManagementService presetManagementService;
     private File imageToResolve = null;
     private String Selectedpreset = "test";
 
@@ -51,15 +48,16 @@ public class MainController {
             ValidatorService validatorService,
             ImageEditorService imageEditorService,
             ResolverProcessorService resolverProcessorService,
-            PresetManagementService presetManagementService
+            PresetManagementService presetManagementService,
+            TemplateFormService templateFormService
             ) {
-        this.applicationContext = applicationContext;
         this.userDialogService = userDialogService;
         this.fileHandlerService = fileHandlerService;
         this.validatorService = validatorService;
         this.imageEditorService = imageEditorService;
         this.resolverProcessorService = resolverProcessorService;
         this.presetManagementService = presetManagementService;
+        this.templateFormService = templateFormService;
     }
 
     @FXML
@@ -115,23 +113,9 @@ public class MainController {
     @FXML
     void openTemplateForm(ActionEvent event) {
         try {
-            FXMLLoader loader = new FXMLLoader(getClass().getResource("../views/templateForm.fxml"));
-            loader.setControllerFactory(applicationContext::getBean);
-            Parent root = loader.load();
-
-            TemplateFormController templateFormController = loader.getController();
-            templateFormController.setFormSubmitListener(newTemplate -> {
+            Stage stage = templateFormService.createAddTemplateForm(newTemplate -> {
                 addSubmittedTemplateToPreset(newTemplate);
-            }
-            );
-
-            Stage stage = new Stage();
-            stage.setTitle("Template Form");
-
-            Scene scene = new Scene(root);
-            stage.setScene(scene);
-
-            stage.initModality(Modality.WINDOW_MODAL);
+            });
 
             stage.initOwner(((Node) event.getSource()).getScene().getWindow());
 

--- a/src/main/java/com/gregorybroche/imageresolver/controller/TemplateItemController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/TemplateItemController.java
@@ -1,21 +1,40 @@
 package com.gregorybroche.imageresolver.controller;
 
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import com.gregorybroche.imageresolver.classes.ImageTemplate;
+import com.gregorybroche.imageresolver.interfaces.TemplateEditFormSubmitListener;
+import com.gregorybroche.imageresolver.service.PresetManagementService;
+import com.gregorybroche.imageresolver.service.TemplateFormService;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
+import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.scene.layout.Pane;
+import javafx.stage.Stage;
 
 @Component
+@Scope("prototype")
 public class TemplateItemController {
-    private int indexInTemplateList;
+    private TemplateFormService templateFormService;
+    private TemplateEditFormSubmitListener editActionListener;
+    private int templateIndex;
+    private ImageTemplate template;
+
+    public TemplateItemController(TemplateFormService templateFormService, PresetManagementService presetManagementService) {
+        this.templateFormService = templateFormService;
+    }
+
+    @FXML
+    private Pane templateDescriptors;
 
     @FXML
     private Label templateName;
@@ -58,9 +77,30 @@ public class TemplateItemController {
 
     @FXML
     /**
-     * placeholder for editing this template
+     * placeholder for opening the modal to edit this template
      */
-    void openEditTemplateModal() {
+    void openEditTemplateModal(ActionEvent event) {
+        try {
+            System.out.println("<TEMPLATE ITEM CONTROLLER> index on open modal :"+this.templateIndex);
+            Stage stage = templateFormService.createTemplateForm(
+                template,
+                templateIndex,
+                (submittedTemplate, indexInTemplateList) -> {
+                    editActionListener.onFormSubmit(submittedTemplate, indexInTemplateList);
+                }
+            );
+
+            stage.initOwner(((Node) event.getSource()).getScene().getWindow());
+
+            stage.showAndWait();
+
+        } catch (Exception e) {
+            System.err.println(e.getMessage());
+        }
+    }
+
+    public void setEmitEditListener(TemplateEditFormSubmitListener listener) {
+        this.editActionListener = listener;
     }
 
     @FXML
@@ -68,7 +108,7 @@ public class TemplateItemController {
      * placeholder for deleting this template
      */
     void deleteTemplate() {
-        System.out.println("implement delete action on " + indexInTemplateList);
+        System.out.println("implement delete action");
     }
 
     /**
@@ -78,22 +118,39 @@ public class TemplateItemController {
      * @param indexInPreset index of the template inside a preset's template list
      */
     public void setTemplateData(ImageTemplate imageTemplate, int indexInPreset) {
-        indexInTemplateList = indexInPreset;
+        System.out.println("<TEMPLATE ITEM CONTROLLER> index on set template data :"+indexInPreset);
+        this.templateIndex = indexInPreset;
+        this.template = imageTemplate;
         setLabels(imageTemplate);
         setFileNamingConvention(imageTemplate);
         setSizeInfo(imageTemplate);
     }
 
+    // private void storeTemplate (ImageTemplate template){
+    //     templateDescriptors.getProperties().put("template", template);
+    // }
+
+    // private ImageTemplate retrieveTemplate(){
+    //     return (ImageTemplate) templateDescriptors.getProperties().get("template");
+    // }
+
+    // private void storeIndexOfTemplate (int index){
+    //     templateDescriptors.getProperties().put("templateIndex", index);
+    // }
+
+    // private int retrieveIndexOfTemplate(){
+    //     Integer index = (Integer) templateDescriptors.getProperties().get("templateIndex");
+    //     return index.intValue();
+    // }
+
     private void setLabels(ImageTemplate imageTemplate) {
-        templateName
-                .setText(imageTemplate.getTemplateName().length() > 0 ? imageTemplate.getTemplateName() : "unnamed");
+        templateName.setText(imageTemplate.getTemplateName().length() > 0 ? imageTemplate.getTemplateName() : "unnamed");
     }
 
     private void setFileNamingConvention(ImageTemplate imageTemplate) {
         prefixColumn.setCellValueFactory(new PropertyValueFactory<>("newImagePrefix"));
         baseNameColumn.setCellValueFactory(new PropertyValueFactory<>("newImageBaseName"));
         suffixColumn.setCellValueFactory(new PropertyValueFactory<>("newImageSuffix"));
-
         ObservableList<ImageTemplate> data = FXCollections.observableArrayList(imageTemplate);
         templateNamingTable.setItems(data);
     }
@@ -103,7 +160,6 @@ public class TemplateItemController {
         heigthColumn.setCellValueFactory(new PropertyValueFactory<>("height"));
         resolutionColumn.setCellValueFactory(new PropertyValueFactory<>("resolution"));
         formatColumn.setCellValueFactory(new PropertyValueFactory<>("format"));
-
         ObservableList<ImageTemplate> data = FXCollections.observableArrayList(imageTemplate);
         templateSpecsTable.setItems(data);
     }

--- a/src/main/java/com/gregorybroche/imageresolver/controller/TemplateItemController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/TemplateItemController.java
@@ -56,13 +56,11 @@ public class TemplateItemController {
     @FXML
     private Button templateDeleteButton;
 
-
     @FXML
     /**
      * placeholder for editing this template
      */
-    void editTemplate() {
-        System.out.println("implement edit window action on "+indexInTemplateList);
+    void openEditTemplateModal() {
     }
 
     @FXML
@@ -70,11 +68,12 @@ public class TemplateItemController {
      * placeholder for deleting this template
      */
     void deleteTemplate() {
-        System.out.println("implement delete action on "+indexInTemplateList);
+        System.out.println("implement delete action on " + indexInTemplateList);
     }
 
     /**
      * sets this template data using a template instance and an index
+     * 
      * @param imageTemplate
      * @param indexInPreset index of the template inside a preset's template list
      */
@@ -86,7 +85,8 @@ public class TemplateItemController {
     }
 
     private void setLabels(ImageTemplate imageTemplate) {
-        templateName.setText(imageTemplate.getTemplateName().length() > 0 ? imageTemplate.getTemplateName() : "unnamed");
+        templateName
+                .setText(imageTemplate.getTemplateName().length() > 0 ? imageTemplate.getTemplateName() : "unnamed");
     }
 
     private void setFileNamingConvention(ImageTemplate imageTemplate) {

--- a/src/main/java/com/gregorybroche/imageresolver/controller/TemplateItemController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/TemplateItemController.java
@@ -77,11 +77,11 @@ public class TemplateItemController {
 
     @FXML
     /**
-     * placeholder for opening the modal to edit this template
+     * opens a modal window to edit the template associated with this controller
+     * @param event
      */
     void openEditTemplateModal(ActionEvent event) {
         try {
-            System.out.println("<TEMPLATE ITEM CONTROLLER> index on open modal :"+this.templateIndex);
             Stage stage = templateFormService.createTemplateForm(
                 template,
                 templateIndex,
@@ -112,36 +112,18 @@ public class TemplateItemController {
     }
 
     /**
-     * sets this template data using a template instance and an index
+     * sets this controller's template data using a template instance and an index
      * 
      * @param imageTemplate
      * @param indexInPreset index of the template inside a preset's template list
      */
     public void setTemplateData(ImageTemplate imageTemplate, int indexInPreset) {
-        System.out.println("<TEMPLATE ITEM CONTROLLER> index on set template data :"+indexInPreset);
         this.templateIndex = indexInPreset;
         this.template = imageTemplate;
         setLabels(imageTemplate);
         setFileNamingConvention(imageTemplate);
         setSizeInfo(imageTemplate);
     }
-
-    // private void storeTemplate (ImageTemplate template){
-    //     templateDescriptors.getProperties().put("template", template);
-    // }
-
-    // private ImageTemplate retrieveTemplate(){
-    //     return (ImageTemplate) templateDescriptors.getProperties().get("template");
-    // }
-
-    // private void storeIndexOfTemplate (int index){
-    //     templateDescriptors.getProperties().put("templateIndex", index);
-    // }
-
-    // private int retrieveIndexOfTemplate(){
-    //     Integer index = (Integer) templateDescriptors.getProperties().get("templateIndex");
-    //     return index.intValue();
-    // }
 
     private void setLabels(ImageTemplate imageTemplate) {
         templateName.setText(imageTemplate.getTemplateName().length() > 0 ? imageTemplate.getTemplateName() : "unnamed");

--- a/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
@@ -3,8 +3,6 @@ package com.gregorybroche.imageresolver.controller;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.management.RuntimeErrorException;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -218,6 +216,11 @@ public class TemplateFormController {
     }
 
     @FXML
+    /**
+     * On form submit will verify if a listener is defined as callback to handle the action and if the inputs are valid
+     * if these conditions are true, an ImageTemplate instance is created and passed to the listener that has been set
+     * for the submit action (either add or edit template)
+     */
     private void handleSubmit() { 
         if(this.submitAddListener == null && this.submitEditListener == null){
             Exception noListenerError = new Exception("No listener set on template form");
@@ -227,7 +230,6 @@ public class TemplateFormController {
         if(!areInputsValid()){
             return;
         }
-        System.out.println("<TEMPLATE FORM CONTROLLER> index on submit :"+indexOfTemplateToEdit);
         try {
             String templateName = validatorService.sanitizeString(inputTemplateName.getText());
             String baseName = validatorService.sanitizeString(inputFileBaseName.getText());
@@ -267,8 +269,12 @@ public class TemplateFormController {
         closeModal();
     }
 
+    /**
+     * set this controllers associated template and its index in case of editing form, also triggers auto filling of fields using the template's data
+     * @param templateToEdit
+     * @param indexToEdit
+     */
     public void setTemplateToEdit(ImageTemplate templateToEdit, int indexToEdit){
-        System.out.println("<TEMPLATE FORM CONTROLLER> index on set Template to edit data :"+indexToEdit);
         this.templateToEdit = templateToEdit;
         this.indexOfTemplateToEdit = indexToEdit;
         setFormatChoiceBox(templateToEdit);
@@ -303,6 +309,9 @@ public class TemplateFormController {
         textElement.setText("");
     }
 
+    /**
+     * sets the value of all input validation booleans to reflect if the associated values are required by defined template contraints
+     */
     private void initializeInputValidationMap() {
         setInputValidationForTemplateName(!templateFormValidatorService.isTemplateNameRequired());
         setInputValidationForBaseName(!templateFormValidatorService.isImageBaseNameRequired());
@@ -318,6 +327,10 @@ public class TemplateFormController {
         buttonSave.setDisable(!mustEnableButton);
     }
 
+    /**
+     * checks if the map of booleans corresponding to validation state of all inputs contains only true values
+     * @return
+     */
     private boolean areInputsValid() {
         return (inputValidationMap.get("templateName")
         && inputValidationMap.get("baseName")
@@ -362,6 +375,10 @@ public class TemplateFormController {
         inputValidationMap.put("format", isInputValid);
     }
 
+    /**
+     * fills all form fields using a template instance as data source, used for loading infos of a template to edit
+     * @param template
+     */
     private void setFieldsOnEditForm(ImageTemplate template){
         setTextInputValue(inputTemplateName, template.getTemplateName());
         setTextInputValue(inputFileBaseName, template.getNewImageBaseName());

--- a/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
@@ -25,6 +25,7 @@ public class TemplateFormController {
     private TemplateFormSubmitListener submitListener;
     private Map<String, Boolean> inputValidationMap = new HashMap<String, Boolean>();
     private Integer indexOfTemplateToEdit = null;
+    private ImageTemplate templateToEdit = null;
 
     @Autowired
     private TemplateFormService templateFormValidatorService;
@@ -99,13 +100,11 @@ public class TemplateFormController {
     @FXML
     private void initialize() {
         initializeInputValidationMap();
-        String[] allowedOutputFormats = templateFormValidatorService.getAllowedFormats();
-        if(indexOfTemplateToEdit != null && indexOfTemplateToEdit < 0){
-            indexOfTemplateToEdit = null;
+        templateFormTitleText.setText(templateToEdit == null ? "ADD TEMPLATE" : "EDIT TEMPLATE");
+        setFormatChoiceBox(templateToEdit);
+        if(templateToEdit != null){
+            setFieldsOnEditForm(templateToEdit);
         }
-        templateFormTitleText.setText(indexOfTemplateToEdit == null ? "ADD TEMPLATE" : "EDIT TEMPLATE");
-        selectFormat.getItems().addAll(allowedOutputFormats);
-        selectFormat.setValue(allowedOutputFormats[0]);
     }
 
     @FXML
@@ -327,5 +326,36 @@ public class TemplateFormController {
 
     private void setInputValidationForFormat(boolean isInputValid) {
         inputValidationMap.put("format", isInputValid);
+    }
+
+    private void setFieldsOnEditForm(ImageTemplate template){
+        setTextInputValue(inputTemplateName, template.getTemplateName());
+        setTextInputValue(inputFileBaseName, template.getNewImageBaseName());
+        setTextInputValue(inputFilePrefix, template.getNewImagePrefix());
+        setTextInputValue(inputFileSuffix, template.getNewImageSuffix());
+        setTextInputValue(inputWidth, String.valueOf(template.getWidth()));
+        setTextInputValue(inputHeight, String.valueOf(template.getHeight()));
+        setTextInputValue(inputResolution, String.valueOf(template.getResolution()));
+    }
+
+    private void setTextInputValue(TextField inputField, String value){
+        if(inputField == null || value == null){
+            return;
+        }
+        inputField.setText(value);
+    }
+
+    /**
+     * Fills the choice box for format using allowed formats defined in ValidatorService. Will initialize selected value to first format
+     * or if there is a template instance given will set the selected value to the template format.
+     * @param template
+     */
+    private void setFormatChoiceBox(ImageTemplate template){
+        String[] allowedOutputFormats = templateFormValidatorService.getAllowedFormats();
+        selectFormat.getItems().addAll(allowedOutputFormats);
+        String defaultSelectedValue = template != null && validatorService.isIncludedIn(template.getFormat(), allowedOutputFormats)
+            ? template.getFormat()
+            : allowedOutputFormats[0];
+        selectFormat.setValue(defaultSelectedValue);
     }
 }

--- a/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
@@ -17,6 +17,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.text.Text;
 import javafx.stage.Stage;
@@ -105,7 +106,6 @@ public class TemplateFormController {
     @FXML
     private void initialize() {
         initializeInputValidationMap();
-        templateFormTitleText.setText(templateToEdit == null ? "ADD TEMPLATE" : "EDIT TEMPLATE");
         String[] allowedOutputFormats = templateFormValidatorService.getAllowedFormats();
         selectFormat.getItems().addAll(allowedOutputFormats);
         selectFormat.setValue(allowedOutputFormats[0]);
@@ -269,6 +269,10 @@ public class TemplateFormController {
         closeModal();
     }
 
+    public void setTitleLabel(String labelText){
+        templateFormTitleText.setText(labelText);
+    }
+
     /**
      * set this controllers associated template and its index in case of editing form, also triggers auto filling of fields using the template's data
      * @param templateToEdit
@@ -280,7 +284,6 @@ public class TemplateFormController {
         setFormatChoiceBox(templateToEdit);
         setFieldsOnEditForm(templateToEdit);
         validateAllInputs();
-
     }
 
     private void validateAllInputs(){

--- a/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/templateFormController.java
@@ -8,7 +8,8 @@ import org.springframework.stereotype.Component;
 
 import com.gregorybroche.imageresolver.classes.ImageTemplate;
 import com.gregorybroche.imageresolver.classes.ValidationResponse;
-import com.gregorybroche.imageresolver.service.TemplateFormValidatorService;
+import com.gregorybroche.imageresolver.interfaces.TemplateFormSubmitListener;
+import com.gregorybroche.imageresolver.service.TemplateFormService;
 import com.gregorybroche.imageresolver.service.ValidatorService;
 
 import javafx.fxml.FXML;
@@ -23,9 +24,10 @@ import javafx.stage.Stage;
 public class TemplateFormController {
     private TemplateFormSubmitListener submitListener;
     private Map<String, Boolean> inputValidationMap = new HashMap<String, Boolean>();
+    private Integer indexOfTemplateToEdit = null;
 
     @Autowired
-    private TemplateFormValidatorService templateFormValidatorService;
+    private TemplateFormService templateFormValidatorService;
 
     @Autowired
     private ValidatorService validatorService;
@@ -34,9 +36,8 @@ public class TemplateFormController {
         this.submitListener = listener;
     }
 
-    public interface TemplateFormSubmitListener {
-        void onFormSubmit(ImageTemplate imageTemplate);
-    }
+    @FXML
+    Text templateFormTitleText;
 
     @FXML
     TextField inputTemplateName;
@@ -96,9 +97,13 @@ public class TemplateFormController {
     Button buttonSave;
 
     @FXML
-    public void initialize() {
+    private void initialize() {
         initializeInputValidationMap();
         String[] allowedOutputFormats = templateFormValidatorService.getAllowedFormats();
+        if(indexOfTemplateToEdit != null && indexOfTemplateToEdit < 0){
+            indexOfTemplateToEdit = null;
+        }
+        templateFormTitleText.setText(indexOfTemplateToEdit == null ? "ADD TEMPLATE" : "EDIT TEMPLATE");
         selectFormat.getItems().addAll(allowedOutputFormats);
         selectFormat.setValue(allowedOutputFormats[0]);
     }
@@ -255,17 +260,17 @@ public class TemplateFormController {
         modalStage.close();
     }
 
-    public void showInputError(Text textElement, String text) {
+    private void showInputError(Text textElement, String text) {
         textElement.setText(text);
         textElement.setVisible(true);
     }
 
-    public void hideInputError(Text textElement) {
+    private void hideInputError(Text textElement) {
         textElement.setVisible(false);
         textElement.setText("");
     }
 
-    public void initializeInputValidationMap() {
+    private void initializeInputValidationMap() {
         setInputValidationForTemplateName(!templateFormValidatorService.isTemplateNameRequired());
         setInputValidationForBaseName(!templateFormValidatorService.isImageBaseNameRequired());
         setInputValidationForPrefix(!templateFormValidatorService.isImagePrefixRequired());
@@ -276,11 +281,11 @@ public class TemplateFormController {
         setInputValidationForFormat(!templateFormValidatorService.isFormatRequired());
     }
 
-    public void toggleSaveButton(boolean mustEnableButton) {
+    private void toggleSaveButton(boolean mustEnableButton) {
         buttonSave.setDisable(!mustEnableButton);
     }
 
-    public boolean areInputsValid() {
+    private boolean areInputsValid() {
         return (inputValidationMap.get("templateName")
         && inputValidationMap.get("baseName")
         && inputValidationMap.get("prefix")
@@ -292,35 +297,35 @@ public class TemplateFormController {
         );
     }
 
-    public void setInputValidationForTemplateName(boolean isInputValid) {
+    private void setInputValidationForTemplateName(boolean isInputValid) {
         inputValidationMap.put("templateName", isInputValid);
     }
 
-    public void setInputValidationForBaseName(boolean isInputValid) {
+    private void setInputValidationForBaseName(boolean isInputValid) {
         inputValidationMap.put("baseName", isInputValid);
     }
 
-    public void setInputValidationForPrefix(boolean isInputValid) {
+    private void setInputValidationForPrefix(boolean isInputValid) {
         inputValidationMap.put("prefix", isInputValid);
     }
 
-    public void setInputValidationForSuffix(boolean isInputValid) {
+    private void setInputValidationForSuffix(boolean isInputValid) {
         inputValidationMap.put("suffix", isInputValid);
     }
 
-    public void setInputValidationForWidth(boolean isInputValid) {
+    private void setInputValidationForWidth(boolean isInputValid) {
         inputValidationMap.put("width", isInputValid);
     }
 
-    public void setInputValidationForHeight(boolean isInputValid) {
+    private void setInputValidationForHeight(boolean isInputValid) {
         inputValidationMap.put("height", isInputValid);
     }
 
-    public void setInputValidationForResolution(boolean isInputValid) {
+    private void setInputValidationForResolution(boolean isInputValid) {
         inputValidationMap.put("resolution", isInputValid);
     }
 
-    public void setInputValidationForFormat(boolean isInputValid) {
+    private void setInputValidationForFormat(boolean isInputValid) {
         inputValidationMap.put("format", isInputValid);
     }
 }

--- a/src/main/java/com/gregorybroche/imageresolver/interfaces/TemplateAddFormSubmitListener.java
+++ b/src/main/java/com/gregorybroche/imageresolver/interfaces/TemplateAddFormSubmitListener.java
@@ -2,6 +2,6 @@ package com.gregorybroche.imageresolver.interfaces;
 
 import com.gregorybroche.imageresolver.classes.ImageTemplate;
 
-public interface TemplateFormSubmitListener {
-    void onFormSubmit(ImageTemplate imageTemplate);
+public interface TemplateAddFormSubmitListener {
+    void onFormSubmit(ImageTemplate submittedTemplate);
 }

--- a/src/main/java/com/gregorybroche/imageresolver/interfaces/TemplateAddFormSubmitListener.java
+++ b/src/main/java/com/gregorybroche/imageresolver/interfaces/TemplateAddFormSubmitListener.java
@@ -2,6 +2,9 @@ package com.gregorybroche.imageresolver.interfaces;
 
 import com.gregorybroche.imageresolver.classes.ImageTemplate;
 
+/**
+ * functional interface to create callbacks and emit submitted data on add template form
+ */
 public interface TemplateAddFormSubmitListener {
     void onFormSubmit(ImageTemplate submittedTemplate);
 }

--- a/src/main/java/com/gregorybroche/imageresolver/interfaces/TemplateEditFormSubmitListener.java
+++ b/src/main/java/com/gregorybroche/imageresolver/interfaces/TemplateEditFormSubmitListener.java
@@ -2,6 +2,9 @@ package com.gregorybroche.imageresolver.interfaces;
 
 import com.gregorybroche.imageresolver.classes.ImageTemplate;
 
+/**
+ * functional interface to create callbacks and emit submitted data on edit template form
+ */
 public interface TemplateEditFormSubmitListener{
     void onFormSubmit(ImageTemplate submittedTemplate, int indexOfTemplateToEdit);
 }

--- a/src/main/java/com/gregorybroche/imageresolver/interfaces/TemplateEditFormSubmitListener.java
+++ b/src/main/java/com/gregorybroche/imageresolver/interfaces/TemplateEditFormSubmitListener.java
@@ -1,0 +1,7 @@
+package com.gregorybroche.imageresolver.interfaces;
+
+import com.gregorybroche.imageresolver.classes.ImageTemplate;
+
+public interface TemplateEditFormSubmitListener{
+    void onFormSubmit(ImageTemplate submittedTemplate, int indexOfTemplateToEdit);
+}

--- a/src/main/java/com/gregorybroche/imageresolver/interfaces/TemplateFormSubmitListener.java
+++ b/src/main/java/com/gregorybroche/imageresolver/interfaces/TemplateFormSubmitListener.java
@@ -1,0 +1,7 @@
+package com.gregorybroche.imageresolver.interfaces;
+
+import com.gregorybroche.imageresolver.classes.ImageTemplate;
+
+public interface TemplateFormSubmitListener {
+    void onFormSubmit(ImageTemplate imageTemplate);
+}

--- a/src/main/java/com/gregorybroche/imageresolver/service/FileHandlerService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/FileHandlerService.java
@@ -18,68 +18,76 @@ public class FileHandlerService {
     private final Path appTempDirectoryPath;
     private final String appPresetsFileName;
     private final Path appPresetsFilePath;
-    
-    public FileHandlerService(  ApplicationContext applicationContext,
-                                UserDialogService userDialogService,
-                                @Value("${resolver.directory.main}") String mainDirectoryName,
-                                @Value("${resolver.directory.temp}") String tempDirectoryName,
-                                @Value("${resolver.file.presets}") String presetFileName,
-                                @Value("${resolver.directory.windows}") String windowsAppMainDirectoryRoot,
-                                @Value("${resolver.directory.unix}") String unixAppMainDirectoryRoot){
+
+    public FileHandlerService(ApplicationContext applicationContext,
+            UserDialogService userDialogService,
+            @Value("${resolver.directory.main}") String mainDirectoryName,
+            @Value("${resolver.directory.temp}") String tempDirectoryName,
+            @Value("${resolver.file.presets}") String presetFileName,
+            @Value("${resolver.directory.windows}") String windowsAppMainDirectoryRoot,
+            @Value("${resolver.directory.unix}") String unixAppMainDirectoryRoot) {
         this.applicationContext = applicationContext;
         this.userDialogService = userDialogService;
         String userTempDirectoryPath = System.getProperty("java.io.tmpdir");
         String userHomeDirectoryPath = System.getProperty("user.home");
 
-        //defining system specific paths to application folder containing the xml preset file
+        // defining system specific paths to application folder containing the xml
+        // preset file
         String osFileAccessorPath;
         String userOperatingSystem = System.getProperty("os.name").toLowerCase();
-        if(userOperatingSystem.contains("win")){
+        if (userOperatingSystem.contains("win")) {
             osFileAccessorPath = windowsAppMainDirectoryRoot;
-        }else if (userOperatingSystem.contains("lin")){
+        } else if (userOperatingSystem.contains("lin")) {
             osFileAccessorPath = unixAppMainDirectoryRoot;
-        }else{
+        } else {
             throw new RuntimeException("This software is not supported on your operating system");
         }
 
         this.appTempDirectoryPath = Paths.get(userTempDirectoryPath, tempDirectoryName);
         this.appDirectoryPath = Paths.get(userHomeDirectoryPath, osFileAccessorPath, mainDirectoryName);
-        this.appPresetsFilePath = Paths.get(userHomeDirectoryPath, osFileAccessorPath, mainDirectoryName, presetFileName);
+        this.appPresetsFilePath = Paths.get(userHomeDirectoryPath, osFileAccessorPath, mainDirectoryName,
+                presetFileName);
         this.appPresetsFileName = presetFileName;
     }
 
-    public Path getAppDirectoryPath(){
+    public Path getAppDirectoryPath() {
         return this.appDirectoryPath;
     }
-    public Path getAppTempDirectoryPath(){
+
+    public Path getAppTempDirectoryPath() {
         return this.appTempDirectoryPath;
     }
 
     /**
-     * Creates copy of a file into the temp folder, will create temp folder if not already present.
+     * Creates copy of a file into the temp folder, will create temp folder if not
+     * already present.
+     * 
      * @param sourceFile
      * @return path of saved file
      * @throws IOException
      */
-    public Path saveFileToTemp(File sourceFile) throws IOException{
-        if(!Files.exists(this.appTempDirectoryPath)){
+    public Path saveFileToTemp(File sourceFile) throws IOException {
+        if (!Files.exists(this.appTempDirectoryPath)) {
             this.createTempFolder();
         }
-        String tempFileName = "temp-"+sourceFile.getName();
+        String tempFileName = "temp-" + sourceFile.getName();
         Path copyFilePath = this.appTempDirectoryPath.resolve(tempFileName);
         Path savedFilePath = Files.copy(sourceFile.toPath(), copyFilePath, StandardCopyOption.REPLACE_EXISTING);
         return savedFilePath;
     }
 
     /**
-     * create an instance of file representing where an edited image will be saved, generate directory if does not already exist
-     * @param imageTemplate image template instance for the file name specification
+     * create an instance of file representing where an edited image will be saved,
+     * generate directory if does not already exist
+     * 
+     * @param imageTemplate   image template instance for the file name
+     *                        specification
      * @param targetDirectory directory where the image must be saved
      * @return File object representing the future file holding the processed image
      * @throws IOException
      */
-    public File setFileToSaveTo(ImageTemplate imageTemplate, Path targetDirectory) throws IOException{
-        if(!Files.exists(targetDirectory)){
+    public File setFileToSaveTo(ImageTemplate imageTemplate, Path targetDirectory) throws IOException {
+        if (!Files.exists(targetDirectory)) {
             this.createFolder(targetDirectory);
         }
         String newImageFullName = imageTemplate.getCompleteFileName();
@@ -89,30 +97,34 @@ public class FileHandlerService {
 
     /**
      * create folder based on given Path instance
+     * 
      * @param directory Path instance of the directory to create
      */
-    public void createFolder(Path directory){
+    public void createFolder(Path directory) {
         try {
             Files.createDirectory(directory);
         } catch (FileAlreadyExistsException e) {
             return;
         } catch (IOException e) {
-            userDialogService.showErrorMessage("Failed directory creation", "Could not create \""+directory+"\" ; Error : "+e.getLocalizedMessage());
+            userDialogService.showErrorMessage("Failed directory creation",
+                    "Could not create \"" + directory + "\" ; Error : " + e.getLocalizedMessage());
             throw new RuntimeException(e);
         }
     }
 
     /**
-     * creates the folder hosting permanent application file (like saved presets and directory for resolved images)
+     * creates the folder hosting permanent application file (like saved presets and
+     * directory for resolved images)
      */
-    public void createAppFolder(){
+    public void createAppFolder() {
         createFolder(this.appDirectoryPath);
     }
-    
+
     /**
-     * creates temp folder used to hold temp data like a copy of the image to be processed
+     * creates temp folder used to hold temp data like a copy of the image to be
+     * processed
      */
-    public void createTempFolder(){
+    public void createTempFolder() {
         createFolder(this.appTempDirectoryPath);
     }
 }

--- a/src/main/java/com/gregorybroche/imageresolver/service/PresetManagementService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/PresetManagementService.java
@@ -28,8 +28,61 @@ public class PresetManagementService {
     public List<Preset> getPresetsFromFile(){
         List<Preset> presetList = new ArrayList<Preset>();
         Preset testPreset = new Preset("test", new ArrayList<ImageTemplate>());
+        addTestTemplates(testPreset);
         presetList.add(testPreset);
         return presetList;
+    }
+
+    private void addTestTemplates(Preset preset){
+        ImageTemplate templateTest1 = new ImageTemplate(
+            "templateTest1",
+            1920,
+            1080,
+            96,
+            "XL",
+            "test-image",
+            null,
+            "jpg"
+        );
+    
+        ImageTemplate templateTest2 = new ImageTemplate(
+            "templateTest2",
+            1080,
+            720,
+            96,
+            "L",
+            "test-image",
+            null,
+            "jpg"
+        );
+    
+        ImageTemplate templateTest3 = new ImageTemplate(
+            "templateTest3",
+            720,
+            480,
+            96,
+            "M",
+            "test-image",
+            null,
+            "jpg"
+        );
+    
+        ImageTemplate templateTest4 = new ImageTemplate(
+            "templateTest4",
+            360,
+            240,
+            96,
+            "S",
+            "test-image",
+            null,
+            "jpg"
+        );
+
+        preset.addTemplate(templateTest1);
+        preset.addTemplate(templateTest2);
+        preset.addTemplate(templateTest3);
+        preset.addTemplate(templateTest4);
+        
     }
 
     public Map<String, Preset> getPresets() {
@@ -49,13 +102,18 @@ public class PresetManagementService {
     public boolean addTemplateToPreset(ImageTemplate template, String presetKey) {
         try {
             Preset presetToModify = presets.get(presetKey);
-            if (presetToModify.isTemplateNameAlreadyPresent(template.getTemplateName())) {
-                return false;
-            }
             return presetToModify.addTemplate(template);
         } catch (Exception e) {
             return false;
         }
-        
+    }
+
+    public boolean editTemplateOfPreset(ImageTemplate newTemplateData, int indexOfPresetToReplace, String presetKey){
+        try {
+            Preset presetToModify = presets.get(presetKey);
+            return presetToModify.editTemplate(newTemplateData, indexOfPresetToReplace);
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/com/gregorybroche/imageresolver/service/PresetManagementService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/PresetManagementService.java
@@ -33,6 +33,10 @@ public class PresetManagementService {
         return presetList;
     }
 
+    /**
+     * Appends predifined templates to a preset for easier testing of GUI interactions without needing to add templates manually every time
+     * @param preset
+     */
     private void addTestTemplates(Preset preset){
         ImageTemplate templateTest1 = new ImageTemplate(
             "templateTest1",
@@ -108,6 +112,13 @@ public class PresetManagementService {
         }
     }
 
+    /**
+     * modifies the data of a template inside of a preset
+     * @param newTemplateData valid ImageTemplate instance providing the data
+     * @param indexOfPresetToReplace index of the template to modify in the preset template list
+     * @param presetKey key identifying the preset on which a template needs editing
+     * @return true if operation has been successful, otherwise false
+     */
     public boolean editTemplateOfPreset(ImageTemplate newTemplateData, int indexOfPresetToReplace, String presetKey){
         try {
             Preset presetToModify = presets.get(presetKey);

--- a/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormService.java
@@ -11,10 +11,12 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 
 import com.gregorybroche.imageresolver.Enums.ConstraintType;
+import com.gregorybroche.imageresolver.classes.ImageTemplate;
 import com.gregorybroche.imageresolver.classes.InputConstraint;
 import com.gregorybroche.imageresolver.classes.ValidationResponse;
 import com.gregorybroche.imageresolver.controller.TemplateFormController;
-import com.gregorybroche.imageresolver.interfaces.TemplateFormSubmitListener;
+import com.gregorybroche.imageresolver.interfaces.TemplateAddFormSubmitListener;
+import com.gregorybroche.imageresolver.interfaces.TemplateEditFormSubmitListener;
 
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
@@ -61,7 +63,11 @@ public class TemplateFormService {
 
     private final Map<String, InputConstraint[]> formConstraints = new HashMap<String, InputConstraint[]>();
 
-    public TemplateFormService(ApplicationContext applicationContext, ValidatorService validatorService, UserDialogService userDialogService) {
+    public TemplateFormService(
+            ApplicationContext applicationContext,
+            ValidatorService validatorService,
+            UserDialogService userDialogService
+            ) {
         this.applicationContext = applicationContext;
         this.validatorService = validatorService;
         this.userDialogService = userDialogService;
@@ -109,19 +115,48 @@ public class TemplateFormService {
      * @return stage of the modal window
      * @throws IOException
      */
-    public Stage createAddTemplateForm(TemplateFormSubmitListener callBackAction) throws IOException{
+    public Stage createTemplateForm(TemplateAddFormSubmitListener callBackAction) throws IOException{
+        FXMLLoader loader = new FXMLLoader(getClass().getResource("../views/templateForm.fxml"));
+        loader.setControllerFactory(applicationContext::getBean);
+            Parent root = loader.load();
+
+            TemplateFormController templateFormController = loader.getController();
+            templateFormController.setAddFormSubmitListener(submittedTemplate -> {
+                callBackAction.onFormSubmit(submittedTemplate);
+            });
+
+            Stage stage = new Stage();
+            stage.setTitle("Add Template Form");
+
+            Scene scene = new Scene(root);
+            stage.setScene(scene);
+
+            stage.initModality(Modality.WINDOW_MODAL);
+
+            return stage;
+    }
+
+    /**
+     * Method responsible for creating the stage of the modal window for editing an existing template
+     * @param templateToEdit action to trigger on form submission based on defined interface
+     * @param indexOfTemplate index of template based on the preset it belongs to
+     * @param callBackAction action to trigger on form submission based on defined interface
+     * @return stage of the modal window
+     * @throws IOException
+     */
+    public Stage createTemplateForm(ImageTemplate templateToEdit, int indexOfTemplate, TemplateEditFormSubmitListener callBackAction) throws IOException{
             FXMLLoader loader = new FXMLLoader(getClass().getResource("../views/templateForm.fxml"));
             loader.setControllerFactory(applicationContext::getBean);
             Parent root = loader.load();
 
             TemplateFormController templateFormController = loader.getController();
-            templateFormController.setFormSubmitListener(newTemplate -> {
-                callBackAction.onFormSubmit(newTemplate);
-            }
+            templateFormController.setTemplateToEdit(templateToEdit, indexOfTemplate);
+            templateFormController.setEditFormSubmitListener( (submittedTemplate, templateIndex) -> {
+                callBackAction.onFormSubmit(submittedTemplate, templateIndex);}
             );
 
             Stage stage = new Stage();
-            stage.setTitle("Add Template Form");
+            stage.setTitle("Edit Template "+templateToEdit.getTemplateName());
 
             Scene scene = new Scene(root);
             stage.setScene(scene);

--- a/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormService.java
@@ -133,9 +133,10 @@ public class TemplateFormService {
         templateFormController.setAddFormSubmitListener(submittedTemplate -> {
             callBackAction.onFormSubmit(submittedTemplate);
         });
-
+        templateFormController.setTitleLabel("ADD TEMPLATE");
         Stage stage = new Stage();
         stage.setTitle("Add Template Form");
+        
 
         Scene scene = new Scene(root);
         stage.setScene(scene);
@@ -168,6 +169,7 @@ public class TemplateFormService {
         templateFormController.setEditFormSubmitListener((submittedTemplate, templateIndex) -> {
             callBackAction.onFormSubmit(submittedTemplate, templateIndex);
         });
+        templateFormController.setTitleLabel("EDIT TEMPLATE");
 
         Stage stage = new Stage();
         stage.setTitle("Edit Template " + templateToEdit.getTemplateName());

--- a/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormService.java
@@ -66,8 +66,7 @@ public class TemplateFormService {
     public TemplateFormService(
             ApplicationContext applicationContext,
             ValidatorService validatorService,
-            UserDialogService userDialogService
-            ) {
+            UserDialogService userDialogService) {
         this.applicationContext = applicationContext;
         this.validatorService = validatorService;
         this.userDialogService = userDialogService;
@@ -84,86 +83,101 @@ public class TemplateFormService {
         return this.allowedFormats;
     }
 
-    public boolean isTemplateNameRequired(){
+    public boolean isTemplateNameRequired() {
         return this.isTemplateNameRequired;
     }
-    public boolean isWidthRequired(){
+
+    public boolean isWidthRequired() {
         return this.isWidthRequired;
     }
-    public boolean isHeightRequired(){
+
+    public boolean isHeightRequired() {
         return this.isHeightRequired;
     }
-    public boolean isResolutionRequired(){
+
+    public boolean isResolutionRequired() {
         return this.isResolutionRequired;
     }
-    public boolean isImagePrefixRequired(){
+
+    public boolean isImagePrefixRequired() {
         return this.isImagePrefixRequired;
     }
-    public boolean isImageSuffixRequired(){
+
+    public boolean isImageSuffixRequired() {
         return this.isImageSuffixRequired;
     }
-    public boolean isImageBaseNameRequired(){
+
+    public boolean isImageBaseNameRequired() {
         return this.isImageBaseNameRequired;
     }
-    public boolean isFormatRequired(){
+
+    public boolean isFormatRequired() {
         return this.isFormatRequired;
     }
 
     /**
-     * Method responsible for creating the stage of the modal window for adding a new template
-     * @param callBackAction action to trigger on form submission based on defined interface
+     * Method responsible for creating the stage of the modal window for adding a
+     * new template
+     * 
+     * @param callBackAction action to trigger on form submission based on defined
+     *                       interface
      * @return stage of the modal window
      * @throws IOException
      */
-    public Stage createTemplateForm(TemplateAddFormSubmitListener callBackAction) throws IOException{
+    public Stage createTemplateForm(TemplateAddFormSubmitListener callBackAction) throws IOException {
         FXMLLoader loader = new FXMLLoader(getClass().getResource("../views/templateForm.fxml"));
         loader.setControllerFactory(applicationContext::getBean);
-            Parent root = loader.load();
+        Parent root = loader.load();
 
-            TemplateFormController templateFormController = loader.getController();
-            templateFormController.setAddFormSubmitListener(submittedTemplate -> {
-                callBackAction.onFormSubmit(submittedTemplate);
-            });
+        TemplateFormController templateFormController = loader.getController();
+        templateFormController.setAddFormSubmitListener(submittedTemplate -> {
+            callBackAction.onFormSubmit(submittedTemplate);
+        });
 
-            Stage stage = new Stage();
-            stage.setTitle("Add Template Form");
+        Stage stage = new Stage();
+        stage.setTitle("Add Template Form");
 
-            Scene scene = new Scene(root);
-            stage.setScene(scene);
+        Scene scene = new Scene(root);
+        stage.setScene(scene);
 
-            stage.initModality(Modality.WINDOW_MODAL);
+        stage.initModality(Modality.WINDOW_MODAL);
 
-            return stage;
+        return stage;
     }
 
     /**
-     * Method responsible for creating the stage of the modal window for editing an existing template
-     * @param templateToEdit action to trigger on form submission based on defined interface
+     * Method responsible for creating the stage of the modal window for editing an
+     * existing template
+     * 
+     * @param templateToEdit  action to trigger on form submission based on defined
+     *                        interface
      * @param indexOfTemplate index of template based on the preset it belongs to
-     * @param callBackAction action to trigger on form submission based on defined interface
+     * @param callBackAction  action to trigger on form submission based on defined
+     *                        interface
      * @return stage of the modal window
      * @throws IOException
      */
-    public Stage createTemplateForm(ImageTemplate templateToEdit, int indexOfTemplate, TemplateEditFormSubmitListener callBackAction) throws IOException{
-            FXMLLoader loader = new FXMLLoader(getClass().getResource("../views/templateForm.fxml"));
-            loader.setControllerFactory(applicationContext::getBean);
-            Parent root = loader.load();
+    public Stage createTemplateForm(ImageTemplate templateToEdit, int indexOfTemplate,
+            TemplateEditFormSubmitListener callBackAction) throws IOException {
+        FXMLLoader loader = new FXMLLoader(getClass().getResource("../views/templateForm.fxml"));
+        loader.setControllerFactory(applicationContext::getBean);
+        Parent root = loader.load();
 
-            TemplateFormController templateFormController = loader.getController();
-            templateFormController.setTemplateToEdit(templateToEdit, indexOfTemplate);
-            templateFormController.setEditFormSubmitListener( (submittedTemplate, templateIndex) -> {
-                callBackAction.onFormSubmit(submittedTemplate, templateIndex);}
-            );
+        TemplateFormController templateFormController = loader.getController();
+        templateFormController.setTemplateToEdit(templateToEdit, indexOfTemplate);
+        templateFormController.setEditFormSubmitListener((submittedTemplate, templateIndex) -> {
+            callBackAction.onFormSubmit(submittedTemplate, templateIndex);
+        });
 
-            Stage stage = new Stage();
-            stage.setTitle("Edit Template "+templateToEdit.getTemplateName());
+        Stage stage = new Stage();
+        stage.setTitle("Edit Template " + templateToEdit.getTemplateName());
 
-            Scene scene = new Scene(root);
-            stage.setScene(scene);
+        Scene scene = new Scene(root);
+        stage.setScene(scene);
 
-            stage.initModality(Modality.WINDOW_MODAL);
+        stage.initModality(Modality.WINDOW_MODAL);
 
-            return stage;
+        return stage;
     }
 
     /**

--- a/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/TemplateFormService.java
@@ -1,19 +1,30 @@
 package com.gregorybroche.imageresolver.service;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 
 import com.gregorybroche.imageresolver.Enums.ConstraintType;
 import com.gregorybroche.imageresolver.classes.InputConstraint;
 import com.gregorybroche.imageresolver.classes.ValidationResponse;
+import com.gregorybroche.imageresolver.controller.TemplateFormController;
+import com.gregorybroche.imageresolver.interfaces.TemplateFormSubmitListener;
+
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
 
 @Service
-public class TemplateFormValidatorService {
+public class TemplateFormService {
+    private ApplicationContext applicationContext;
     private ValidatorService validatorService;
     private UserDialogService userDialogService;
 
@@ -50,7 +61,8 @@ public class TemplateFormValidatorService {
 
     private final Map<String, InputConstraint[]> formConstraints = new HashMap<String, InputConstraint[]>();
 
-    public TemplateFormValidatorService(ValidatorService validatorService, UserDialogService userDialogService) {
+    public TemplateFormService(ApplicationContext applicationContext, ValidatorService validatorService, UserDialogService userDialogService) {
+        this.applicationContext = applicationContext;
         this.validatorService = validatorService;
         this.userDialogService = userDialogService;
         Set<String> allowedFormatsSet = validatorService.getAllowedImageFormatsAsExtension();
@@ -89,6 +101,34 @@ public class TemplateFormValidatorService {
     }
     public boolean isFormatRequired(){
         return this.isFormatRequired;
+    }
+
+    /**
+     * Method responsible for creating the stage of the modal window for adding a new template
+     * @param callBackAction action to trigger on form submission based on defined interface
+     * @return stage of the modal window
+     * @throws IOException
+     */
+    public Stage createAddTemplateForm(TemplateFormSubmitListener callBackAction) throws IOException{
+            FXMLLoader loader = new FXMLLoader(getClass().getResource("../views/templateForm.fxml"));
+            loader.setControllerFactory(applicationContext::getBean);
+            Parent root = loader.load();
+
+            TemplateFormController templateFormController = loader.getController();
+            templateFormController.setFormSubmitListener(newTemplate -> {
+                callBackAction.onFormSubmit(newTemplate);
+            }
+            );
+
+            Stage stage = new Stage();
+            stage.setTitle("Add Template Form");
+
+            Scene scene = new Scene(root);
+            stage.setScene(scene);
+
+            stage.initModality(Modality.WINDOW_MODAL);
+
+            return stage;
     }
 
     /**

--- a/src/main/java/com/gregorybroche/imageresolver/views/templateComponent.fxml
+++ b/src/main/java/com/gregorybroche/imageresolver/views/templateComponent.fxml
@@ -26,7 +26,7 @@
                         <TableColumn fx:id="formatColumn" prefWidth="60.0" resizable="false" sortable="false" text="Format" />
                     </columns>
                 </TableView>
-                <Button fx:id="templateEditButton" layoutX="80.0" layoutY="160.0" mnemonicParsing="false" onAction="#editTemplate" prefHeight="25.0" prefWidth="75.0" text="Edit" />
+                <Button fx:id="templateEditButton" layoutX="80.0" layoutY="160.0" mnemonicParsing="false" onAction="#openEditTemplateModal" prefHeight="25.0" prefWidth="75.0" text="Edit" />
                 <Button fx:id="templateDeleteButton" layoutX="175.0" layoutY="160.0" mnemonicParsing="false" onAction="#deleteTemplate" prefHeight="25.0" prefWidth="75.0" style="-fx-background-color: red;" text="Delete" />
             </children>
         </Pane>

--- a/src/main/java/com/gregorybroche/imageresolver/views/templateForm.fxml
+++ b/src/main/java/com/gregorybroche/imageresolver/views/templateForm.fxml
@@ -15,8 +15,8 @@
          <children>
             <Pane layoutX="15.0" layoutY="14.0" prefHeight="65.0" prefWidth="471.0">
                <children>
-                  <Text fx:id="templateFormTitleText" layoutX="138.0" layoutY="20.0" text="ADD TEMPLATE" />
-                  <TextField fx:id="inputTemplateName" layoutX="250.0" layoutY="3.0" onKeyTyped="#validateTemplateNameChange" />
+                  <Text fx:id="templateFormTitleText" layoutX="120.0" layoutY="20.0" text="" />
+                  <TextField fx:id="inputTemplateName" layoutX="225.0" layoutY="3.0" onKeyTyped="#validateTemplateNameChange" />
                   <Text fx:id="inputTemplateNameError" fill="#cd2828" layoutX="164.0" layoutY="46.0" strokeType="OUTSIDE" strokeWidth="0.0" text="" visible="false" />
                </children>
             </Pane>

--- a/src/main/java/com/gregorybroche/imageresolver/views/templateForm.fxml
+++ b/src/main/java/com/gregorybroche/imageresolver/views/templateForm.fxml
@@ -15,9 +15,9 @@
          <children>
             <Pane layoutX="15.0" layoutY="14.0" prefHeight="65.0" prefWidth="471.0">
                <children>
+                  <Text fx:id="templateFormTitleText" layoutX="138.0" layoutY="20.0" text="ADD TEMPLATE" />
                   <TextField fx:id="inputTemplateName" layoutX="250.0" layoutY="3.0" onKeyTyped="#validateTemplateNameChange" />
-                  <Label fx:id="templateFormTitleLabel" layoutX="140.0" layoutY="8.0" text="ADD TEMPLATE" />
-                  <Text fx:id="inputTemplateNameError" fill="#cd2828" layoutX="164.0" layoutY="46.0" strokeType="OUTSIDE" strokeWidth="0.0" visible="false" text="" />
+                  <Text fx:id="inputTemplateNameError" fill="#cd2828" layoutX="164.0" layoutY="46.0" strokeType="OUTSIDE" strokeWidth="0.0" text="" visible="false" />
                </children>
             </Pane>
             <Pane layoutX="15.0" layoutY="80.0" prefHeight="105.0" prefWidth="470.0">
@@ -28,9 +28,9 @@
                   <TextField fx:id="inputFileBaseName" layoutX="46.0" layoutY="8.0" onKeyTyped="#validateImageBaseNameChange" />
                   <TextField fx:id="inputFilePrefix" layoutX="46.0" layoutY="41.0" onKeyTyped="#validateImagePrefixChange" />
                   <TextField fx:id="inputFileSuffix" layoutX="46.0" layoutY="73.0" onKeyTyped="#validateImageSuffixChange" />
-                  <Text fx:id="inputFileBaseNameError" fill="#cd2828" layoutX="211.0" layoutY="25.0" strokeType="OUTSIDE" strokeWidth="0.0" visible="false" text="" />
-                  <Text fx:id="inputFilePrefixError" fill="#cd2828" layoutX="211.0" layoutY="60.0" strokeType="OUTSIDE" strokeWidth="0.0" visible="false" text="" />
-                  <Text fx:id="inputFileSuffixError" fill="#cd2828" layoutX="211.0" layoutY="90.0" strokeType="OUTSIDE" strokeWidth="0.0" visible="false" text="" />
+                  <Text fx:id="inputFileBaseNameError" fill="#cd2828" layoutX="211.0" layoutY="25.0" strokeType="OUTSIDE" strokeWidth="0.0" text="" visible="false" />
+                  <Text fx:id="inputFilePrefixError" fill="#cd2828" layoutX="211.0" layoutY="60.0" strokeType="OUTSIDE" strokeWidth="0.0" text="" visible="false" />
+                  <Text fx:id="inputFileSuffixError" fill="#cd2828" layoutX="211.0" layoutY="90.0" strokeType="OUTSIDE" strokeWidth="0.0" text="" visible="false" />
                </children>
             </Pane>
             <Pane layoutX="15.0" layoutY="185.0" prefHeight="160.0" prefWidth="470.0">
@@ -43,18 +43,18 @@
                   <Label layoutX="-1.0" layoutY="133.0" text="Res" />
                   <TextField fx:id="inputResolution" layoutX="45.0" layoutY="129.0" onKeyTyped="#validateResolutionChange" prefHeight="25.0" prefWidth="101.0" />
                   <Label layoutY="100.0" text="Format" />
-                  <ChoiceBox fx:id="selectFormat" layoutX="45.0" layoutY="96.0" prefWidth="150.0" onAction="#validateFormatChange"/>
+                  <ChoiceBox fx:id="selectFormat" layoutX="45.0" layoutY="96.0" onAction="#validateFormatChange" prefWidth="150.0" />
                   <Label layoutX="146.0" layoutY="133.0" text="px/inc" />
-                  <Text fx:id="inputWidthError" fill="#cd2828" layoutX="210.0" layoutY="49.0" strokeType="OUTSIDE" strokeWidth="0.0" visible="false" text="" />
-                  <Text fx:id="inputHeightError" fill="#cd2828" layoutX="210.0" layoutY="80.0" strokeType="OUTSIDE" strokeWidth="0.0" visible="false" text="" />
-                  <Text fx:id="selectFormatError" fill="#cd2828" layoutX="210.0" layoutY="113.0" strokeType="OUTSIDE" strokeWidth="0.0" visible="false" text="" />
-                  <Text fx:id="inputResolutionError" fill="#cd2828" layoutX="210.0" layoutY="146.0" strokeType="OUTSIDE" strokeWidth="0.0" visible="false" text="" />
+                  <Text fx:id="inputWidthError" fill="#cd2828" layoutX="210.0" layoutY="49.0" strokeType="OUTSIDE" strokeWidth="0.0" text="" visible="false" />
+                  <Text fx:id="inputHeightError" fill="#cd2828" layoutX="210.0" layoutY="80.0" strokeType="OUTSIDE" strokeWidth="0.0" text="" visible="false" />
+                  <Text fx:id="selectFormatError" fill="#cd2828" layoutX="210.0" layoutY="113.0" strokeType="OUTSIDE" strokeWidth="0.0" text="" visible="false" />
+                  <Text fx:id="inputResolutionError" fill="#cd2828" layoutX="210.0" layoutY="146.0" strokeType="OUTSIDE" strokeWidth="0.0" text="" visible="false" />
                </children>
             </Pane>
             <Pane layoutX="15.0" layoutY="345.0" prefHeight="50.0" prefWidth="470.0">
                <children>
-                  <Button fx:id="buttonSave" layoutX="355.0" layoutY="13.0" mnemonicParsing="false" prefHeight="25.0" prefWidth="75.0" text="Save" onAction="#handleSubmit" disable="true" />
-                  <Button fx:id="buttonCancel" layoutX="255.0" layoutY="13.0" mnemonicParsing="false" prefHeight="25.0" prefWidth="75.0" text="Cancel" onAction="#cancelForm" />
+                  <Button fx:id="buttonSave" disable="true" layoutX="355.0" layoutY="13.0" mnemonicParsing="false" onAction="#handleSubmit" prefHeight="25.0" prefWidth="75.0" text="Save" />
+                  <Button fx:id="buttonCancel" layoutX="255.0" layoutY="13.0" mnemonicParsing="false" onAction="#cancelForm" prefHeight="25.0" prefWidth="75.0" text="Cancel" />
                </children>
             </Pane>
          </children>

--- a/src/test/java/com/gregorybroche/imageresolver/service/PresetManagementServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/PresetManagementServiceTest.java
@@ -16,6 +16,8 @@ import com.gregorybroche.imageresolver.classes.Preset;
 
 public class PresetManagementServiceTest {
     private PresetManagementService presetManagementService;
+    private Preset preset1 = new Preset("preset1", new ArrayList<ImageTemplate>());
+    private Preset preset2 = new Preset("preset2", new ArrayList<ImageTemplate>());
     private ImageTemplate templateTest1 = new ImageTemplate(
         "templateTest1",
         1920,
@@ -164,6 +166,122 @@ public class PresetManagementServiceTest {
 
             boolean resultCollision = presetManagementService.addTemplateToPreset(templateTest1, "presetTest");
             assertFalse(resultCollision);
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    void editTemplateOfPreset_presetKeyIsNull_shouldReturnFalseAndUnchangedTemplateWhenEditing(){
+        try {
+            preset1.addTemplate(templateTest1);
+            List<Preset> testPresets = new ArrayList<Preset>();
+            testPresets.add(preset1);
+            testPresets.add(preset2);
+            presetManagementService.setPresets(testPresets);
+            assertEquals(presetManagementService.getPresetFromKey("preset1").getName(), "preset1");
+            assertEquals(presetManagementService.getPresetFromKey("preset2").getName(), "preset2");
+            assertEquals(presetManagementService.getPresetFromKey("preset1").getTemplates().getFirst().getTemplateName(), "templateTest1");
+            boolean editResult = presetManagementService.editTemplateOfPreset(templateTest3, 0, null);
+            assertFalse(editResult);
+            assertEquals(presetManagementService.getPresetFromKey("preset1").getTemplates().getFirst().getTemplateName(), "templateTest1");
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    void editTemplateOfPreset_presetKeyIsWrong_shouldReturnFalseAndUnchangedTemplateWhenEditing(){
+        try {
+            preset1.addTemplate(templateTest1);
+            List<Preset> testPresets = new ArrayList<Preset>();
+            testPresets.add(preset1);
+            testPresets.add(preset2);
+            presetManagementService.setPresets(testPresets);
+            assertEquals(presetManagementService.getPresetFromKey("preset1").getName(), "preset1");
+            assertEquals(presetManagementService.getPresetFromKey("preset2").getName(), "preset2");
+            assertEquals(presetManagementService.getPresetFromKey("preset1").getTemplates().getFirst().getTemplateName(), "templateTest1");
+            boolean editResult = presetManagementService.editTemplateOfPreset(templateTest3, 0, "wrongKey");
+            assertFalse(editResult);
+            assertEquals(presetManagementService.getPresetFromKey("preset1").getTemplates().getFirst().getTemplateName(), "templateTest1");
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    void editTemplateOfPreset_presetKeyIsRightButTemplateNameTaken_shouldReturnFalseAndUnchangedTemplateWhenEditing(){
+        try {
+            preset1.addTemplate(templateTest1);
+            preset1.addTemplate(templateTest2);
+            preset1.addTemplate(templateTest3);
+            List<Preset> testPresets = new ArrayList<Preset>();
+            testPresets.add(preset1);
+            testPresets.add(preset2);
+            presetManagementService.setPresets(testPresets);
+            assertEquals(presetManagementService.getPresetFromKey("preset1").getName(), "preset1");
+            assertEquals(presetManagementService.getPresetFromKey("preset2").getName(), "preset2");
+            assertEquals(presetManagementService.getPresetFromKey("preset1").getTemplates().getFirst().getTemplateName(), "templateTest1");
+            ImageTemplate editSourceTemplateWithNameCollision = new ImageTemplate(
+                "templateTest2",
+                1081,
+                721,
+                90,
+                "L_edit-",
+                "test_edit",
+                "-edited_ver",
+                "webp"
+                );
+            boolean editResult = presetManagementService.editTemplateOfPreset(
+                editSourceTemplateWithNameCollision,
+                0,
+                "preset1"
+                );
+            assertFalse(editResult);
+            assertEquals(presetManagementService.getPresetFromKey("preset1").getTemplates().getFirst().getTemplateName(), "templateTest1");
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    void editTemplateOfPreset_presetKeyIsRightAndEditTemplateDataIsValid_shouldReturnTrueAndChangedTemplateWhenEditing(){
+        try {
+            preset1.addTemplate(templateTest1);
+            preset1.addTemplate(templateTest2);
+            preset1.addTemplate(templateTest3);
+            List<Preset> testPresets = new ArrayList<Preset>();
+            testPresets.add(preset1);
+            testPresets.add(preset2);
+            presetManagementService.setPresets(testPresets);
+            assertEquals(presetManagementService.getPresetFromKey("preset1").getName(), "preset1");
+            assertEquals(presetManagementService.getPresetFromKey("preset2").getName(), "preset2");
+            assertEquals(presetManagementService.getPresetFromKey("preset1").getTemplates().getFirst().getTemplateName(), "templateTest1");
+            ImageTemplate editSourceTemplate = new ImageTemplate(
+                "templateTest1-edited",
+                1921,
+                1081,
+                90,
+                "XL_edit-",
+                "test_edit",
+                "-edited_ver",
+                "webp"
+                );
+            boolean editResult = presetManagementService.editTemplateOfPreset(
+                editSourceTemplate,
+                0,
+                "preset1"
+                );
+            assertTrue(editResult);
+            ImageTemplate editedTemplate = presetManagementService.getPresetFromKey("preset1").getTemplates().getFirst();
+            assertEquals(editedTemplate.getTemplateName(), "templateTest1-edited");
+            assertEquals(editedTemplate.getWidth(), 1921);
+            assertEquals(editedTemplate.getHeight(), 1081);
+            assertEquals(editedTemplate.getResolution(), 90);
+            assertEquals(editedTemplate.getNewImagePrefix(), "XL_edit-");
+            assertEquals(editedTemplate.getNewImageBaseName(), "test_edit");
+            assertEquals(editedTemplate.getNewImageSuffix(), "-edited_ver");
+            assertEquals(editedTemplate.getFormat(), "webp");
         } catch (Exception e) {
             fail();
         }

--- a/src/test/java/com/gregorybroche/imageresolver/service/TemplateFormServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/TemplateFormServiceTest.java
@@ -13,22 +13,22 @@ import org.junit.jupiter.api.Test;
 import com.gregorybroche.imageresolver.classes.InputConstraint;
 import com.gregorybroche.imageresolver.classes.ValidationResponse;
 
-public class TemplateFormValidatorServiceTest {
-    private TemplateFormValidatorService templateSubmitterService;
+public class TemplateFormServiceTest {
+    private TemplateFormService templateFormService;
 
     @BeforeEach
     void setUp(){
         ValidatorService validatorService = new ValidatorService();
         UserDialogService userDialogService = new UserDialogService(validatorService);
-        templateSubmitterService = new TemplateFormValidatorService(validatorService, userDialogService);
+        templateFormService = new TemplateFormService(null, validatorService, userDialogService);
     }
 
     @Test
     void generateTemplateNameConstraints_shouldReturnAdequateConstraints() {
         try {
-            Method generateTemplateNameConstraintsMethod = TemplateFormValidatorService.class.getDeclaredMethod("generateTemplateNameConstraints");
+            Method generateTemplateNameConstraintsMethod = TemplateFormService.class.getDeclaredMethod("generateTemplateNameConstraints");
             generateTemplateNameConstraintsMethod.setAccessible(true);
-            InputConstraint[] templateNameConstraints = (InputConstraint[]) generateTemplateNameConstraintsMethod.invoke(this.templateSubmitterService);
+            InputConstraint[] templateNameConstraints = (InputConstraint[]) generateTemplateNameConstraintsMethod.invoke(this.templateFormService);
             assertEquals(templateNameConstraints[0].getConstraintName(), "requiredTemplateName");
         } catch (Exception e) {
             fail("Exception triggered " + e.getMessage());
@@ -36,46 +36,46 @@ public class TemplateFormValidatorServiceTest {
     }
 
     @Test
-    void setAllConstraints_TemplateSubmitterServiceFormConstraints_shouldContainAllConstraintsNames() {
-        this.templateSubmitterService.setAllConstraints();
-        InputConstraint[] templateNameConstraints = templateSubmitterService.getFormConstraints().get("templateName");
+    void setAllConstraints_templateFormServiceFormConstraints_shouldContainAllConstraintsNames() {
+        this.templateFormService.setAllConstraints();
+        InputConstraint[] templateNameConstraints = templateFormService.getFormConstraints().get("templateName");
         assertEquals(templateNameConstraints[0].getConstraintName(), "requiredTemplateName");
-        InputConstraint[] widthConstraints = templateSubmitterService.getFormConstraints().get("width");
+        InputConstraint[] widthConstraints = templateFormService.getFormConstraints().get("width");
         assertEquals(widthConstraints[0].getConstraintName(), "requiredWidth");
-        InputConstraint[] heightConstraints = templateSubmitterService.getFormConstraints().get("height");
+        InputConstraint[] heightConstraints = templateFormService.getFormConstraints().get("height");
         assertEquals(heightConstraints[0].getConstraintName(), "requiredHeight");
-        InputConstraint[] resolutionConstraints = templateSubmitterService.getFormConstraints().get("resolution");
+        InputConstraint[] resolutionConstraints = templateFormService.getFormConstraints().get("resolution");
         assertEquals(resolutionConstraints[0].getConstraintName(), "requiredResolution");
-        InputConstraint[] prefixConstraints = templateSubmitterService.getFormConstraints().get("prefix");
+        InputConstraint[] prefixConstraints = templateFormService.getFormConstraints().get("prefix");
         assertEquals(prefixConstraints[0].getConstraintName(), "requiredImagePrefix");
-        InputConstraint[] formatConstraints = templateSubmitterService.getFormConstraints().get("format");
+        InputConstraint[] formatConstraints = templateFormService.getFormConstraints().get("format");
         assertEquals(formatConstraints[0].getConstraintName(), "requiredFormat");
     }
 
     @Test
     void validateInput_widthIsNull_shouldReturnValidationResponseFalseWithErrorWidthIsRequired(){
-        this.templateSubmitterService.setAllConstraints();
-        ValidationResponse testResponse = this.templateSubmitterService.validateInput(null, "width");
+        this.templateFormService.setAllConstraints();
+        ValidationResponse testResponse = this.templateFormService.validateInput(null, "width");
         assertFalse(testResponse.getIsSuccess());
         assertEquals(testResponse.getMessage(), "The width is required");
     }
 
     @Test
     void validateInput_widthIsLessThanAllowed_shouldReturnValidationResponseFalseWithErrorWidthLessThanAllowed(){
-        this.templateSubmitterService.setAllConstraints();
+        this.templateFormService.setAllConstraints();
         String value = "5";
         String expectedMessage = "The width must be an int greater than";
-        ValidationResponse testResponse = this.templateSubmitterService.validateInput(value, "width");
+        ValidationResponse testResponse = this.templateFormService.validateInput(value, "width");
         assertFalse(testResponse.getIsSuccess());
         assertTrue(testResponse.getMessage().contains(expectedMessage));
     }
 
     @Test
     void validateInput_widthIsMoreThanAllowed_shouldReturnValidationResponseFalseWithErrorWidthGreaterThanAllowed(){
-        this.templateSubmitterService.setAllConstraints();
+        this.templateFormService.setAllConstraints();
         String value = "11000";
         String expectedMessage = "The width must be an int less than";
-        ValidationResponse testResponse = this.templateSubmitterService.validateInput(value, "width");
+        ValidationResponse testResponse = this.templateFormService.validateInput(value, "width");
         assertFalse(testResponse.getIsSuccess());
         assertTrue(testResponse.getMessage().contains(expectedMessage));
     }

--- a/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/service/ValidatorServiceTest.java
@@ -25,7 +25,7 @@ public class ValidatorServiceTest {
     ValidatorService validatorService;
     ImageEditorService imageEditorService;
     UserDialogService userDialogService;
-    TemplateFormValidatorService templateSubmitterService;
+    TemplateFormService templateFormService;
     BufferedImage testImageBufferedContent;
 
     @TempDir
@@ -36,7 +36,7 @@ public class ValidatorServiceTest {
         validatorService = new ValidatorService(); 
         userDialogService = new UserDialogService(validatorService);
         imageEditorService = new ImageEditorService(validatorService, userDialogService);
-        templateSubmitterService = new TemplateFormValidatorService(this.validatorService, userDialogService);
+        templateFormService = new TemplateFormService(null, this.validatorService, userDialogService);
         ReflectionTestUtils.setField(validatorService, "allowedImageMimeTypes", testAllowedImageMimeTypes);
         ReflectionTestUtils.setField(validatorService, "allowedImageFormats", testAllowedImageFormats);
     }
@@ -422,13 +422,13 @@ public class ValidatorServiceTest {
     @Test
     void isIncludedIn_valueIsNotInArrayUsingRealConstraint_ShouldReturnFalse() {
         String value = "tiff";
-        assertFalse(validatorService.isIncludedIn(value, templateSubmitterService.getAllowedFormats()));
+        assertFalse(validatorService.isIncludedIn(value, templateFormService.getAllowedFormats()));
     }
 
     @Test
     void isIncludedIn_valueIsInArrayUsingRealConstraint_ShouldReturnTrue() {
         String value = "webp";
-        assertTrue(validatorService.isIncludedIn(value, templateSubmitterService.getAllowedFormats()));
+        assertTrue(validatorService.isIncludedIn(value, templateFormService.getAllowedFormats()));
     }
 
     /* ***** isConstraintValidated ***** */


### PR DESCRIPTION
Added ability to edit a template of the currently selected preset by refactoring some existing logic and reusing the same form component and providing added context.
added Spring scope "prototype" annotation on template item components to correctly create multiple instances instead of the default singleton behavior which was causing necessary properties to be overwritten when several templates existed.