### PR TITLE
added ordering of active preset's template list

### DIFF
--- a/src/main/java/com/gregorybroche/imageresolver/classes/Preset.java
+++ b/src/main/java/com/gregorybroche/imageresolver/classes/Preset.java
@@ -1,6 +1,9 @@
 package com.gregorybroche.imageresolver.classes;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 public class Preset {
@@ -27,6 +30,17 @@ public class Preset {
     public List<ImageTemplate> getTemplates() {
         return this.templates;
     }
+
+    /**
+     * comparator to sort templates by decreasing width property
+     */
+    public static Comparator<ImageTemplate> decreasingWidthComparator = new Comparator<ImageTemplate>() {
+        public int compare(ImageTemplate template1, ImageTemplate template2){
+            int width1 = template1.getWidth();
+            int width2 = template2.getWidth();
+            return width2 - width1;
+        }
+    };
 
     /**
      * checks if a name string already corresponds to an existing template name in
@@ -112,7 +126,10 @@ public class Preset {
         } catch (Exception e) {
             return false;
         }
+    }
 
+    public void orderTemplatesByWidth(){
+        Collections.sort(this.templates, Preset.decreasingWidthComparator);
     }
 
 }

--- a/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
+++ b/src/main/java/com/gregorybroche/imageresolver/controller/MainController.java
@@ -80,6 +80,7 @@ public class MainController {
     @FXML
     public void initialize() {
         presetManagementService.loadPresets();
+        presetManagementService.orderTemplatesOfPresetByWidth(Selectedpreset);
         displayLoadedTemplates();
     }
 
@@ -165,6 +166,7 @@ public class MainController {
      */
     private void addSubmittedTemplateToPreset(ImageTemplate submittedTemplate) {
         presetManagementService.addTemplateToPreset(submittedTemplate, Selectedpreset);
+        presetManagementService.orderTemplatesOfPresetByWidth(Selectedpreset);
         displayLoadedTemplates();
     }
 
@@ -175,6 +177,7 @@ public class MainController {
      */
     private void editTemplate(ImageTemplate submittedTemplate, int indexOfTemplateToEdit) {
         presetManagementService.editTemplateOfPreset(submittedTemplate, indexOfTemplateToEdit, Selectedpreset);
+        presetManagementService.orderTemplatesOfPresetByWidth(Selectedpreset);
         displayLoadedTemplates();
     }
 

--- a/src/main/java/com/gregorybroche/imageresolver/service/PresetManagementService.java
+++ b/src/main/java/com/gregorybroche/imageresolver/service/PresetManagementService.java
@@ -14,18 +14,20 @@ import com.gregorybroche.imageresolver.classes.Preset;
 public class PresetManagementService {
     private Map<String, Preset> presets = new HashMap<String, Preset>();
 
-    public void loadPresets(){
+    public void loadPresets() {
         List<Preset> presetList = getPresetsFromFile();
         setPresets(presetList);
     }
-    public void setPresets(List<Preset> presetList){
+
+    public void setPresets(List<Preset> presetList) {
         presetList.forEach(preset -> {
             this.presets.put(preset.getName(), preset);
         });
     }
 
-    //placeholder to maintain logic, to replace with proper method once saving to file is implemented
-    public List<Preset> getPresetsFromFile(){
+    // placeholder to maintain logic, to replace with proper method once saving to
+    // file is implemented
+    public List<Preset> getPresetsFromFile() {
         List<Preset> presetList = new ArrayList<Preset>();
         Preset testPreset = new Preset("test", new ArrayList<ImageTemplate>());
         addTestTemplates(testPreset);
@@ -34,59 +36,57 @@ public class PresetManagementService {
     }
 
     /**
-     * Appends predifined templates to a preset for easier testing of GUI interactions without needing to add templates manually every time
+     * Appends predifined templates to a preset for easier testing of GUI
+     * interactions without needing to add templates manually every time
+     * 
      * @param preset
      */
-    private void addTestTemplates(Preset preset){
+    private void addTestTemplates(Preset preset) {
         ImageTemplate templateTest1 = new ImageTemplate(
-            "templateTest1",
-            1920,
-            1080,
-            96,
-            "XL",
-            "test-image",
-            null,
-            "jpg"
-        );
-    
+                "templateTest1",
+                1920,
+                1080,
+                96,
+                "XL",
+                "test-image",
+                null,
+                "jpg");
+
         ImageTemplate templateTest2 = new ImageTemplate(
-            "templateTest2",
-            1080,
-            720,
-            96,
-            "L",
-            "test-image",
-            null,
-            "jpg"
-        );
-    
+                "templateTest2",
+                1080,
+                720,
+                96,
+                "L",
+                "test-image",
+                null,
+                "jpg");
+
         ImageTemplate templateTest3 = new ImageTemplate(
-            "templateTest3",
-            720,
-            480,
-            96,
-            "M",
-            "test-image",
-            null,
-            "jpg"
-        );
-    
+                "templateTest3",
+                720,
+                480,
+                96,
+                "M",
+                "test-image",
+                null,
+                "jpg");
+
         ImageTemplate templateTest4 = new ImageTemplate(
-            "templateTest4",
-            360,
-            240,
-            96,
-            "S",
-            "test-image",
-            null,
-            "jpg"
-        );
+                "templateTest4",
+                360,
+                240,
+                96,
+                "S",
+                "test-image",
+                null,
+                "jpg");
 
         preset.addTemplate(templateTest1);
         preset.addTemplate(templateTest2);
         preset.addTemplate(templateTest3);
         preset.addTemplate(templateTest4);
-        
+
     }
 
     public Map<String, Preset> getPresets() {
@@ -99,7 +99,8 @@ public class PresetManagementService {
 
     /**
      * add a template to one of the loaded presets using its name key for reference
-     * @param template template to add
+     * 
+     * @param template  template to add
      * @param presetKey name of the preset to which template must be added
      * @return true if operation is successfull, otherwise false
      */
@@ -114,15 +115,19 @@ public class PresetManagementService {
 
     /**
      * modifies the data of a template inside of a preset
-     * @param newTemplateData valid ImageTemplate instance providing the data
-     * @param indexOfTemplateToReplace index of the template to modify in the preset template list
-     * @param presetKey key identifying the preset on which a template needs editing
+     * 
+     * @param newTemplateData          valid ImageTemplate instance providing the
+     *                                 data
+     * @param indexOfTemplateToReplace index of the template to modify in the preset
+     *                                 template list
+     * @param presetKey                key identifying the preset on which a
+     *                                 template needs editing
      * @return true if operation has been successful, otherwise false
      */
-    public boolean editTemplateOfPreset(ImageTemplate newTemplateData, int indexOfTemplateToReplace, String presetKey){
+    public boolean editTemplateOfPreset(ImageTemplate newTemplateData, int indexOfTemplateToReplace, String presetKey) {
         try {
             Preset presetToModify = presets.get(presetKey);
-            if(presetToModify == null){
+            if (presetToModify == null) {
                 return false;
             }
             return presetToModify.editTemplate(newTemplateData, indexOfTemplateToReplace);
@@ -133,19 +138,33 @@ public class PresetManagementService {
 
     /**
      * deletes a template from a preset template list
-     * @param indexOfTemplateToDelete index of the template to delete in the preset template list
-     * @param presetKey key to retrieve the appropriate preset on which a template must be remove
+     * 
+     * @param indexOfTemplateToDelete index of the template to delete in the preset
+     *                                template list
+     * @param presetKey               key to retrieve the appropriate preset on
+     *                                which a template must be remove
      * @return true if delete action was successful, false otherwise
      */
-    public boolean deleteTemplateOfPreset(int indexOfTemplateToDelete, String presetKey){
+    public boolean deleteTemplateOfPreset(int indexOfTemplateToDelete, String presetKey) {
         try {
             Preset presetToModify = presets.get(presetKey);
-            if(presetToModify == null){
+            if (presetToModify == null) {
                 return false;
             }
             return presetToModify.deleteTemplate(indexOfTemplateToDelete);
         } catch (Exception e) {
             return false;
         }
+    }
+
+    /**
+     * orders templates of a preset template list
+     * @param presetKey key to retrieve the appropriate preset to order
+     */
+    public void orderTemplatesOfPresetByWidth(String presetKey){
+
+            Preset presetToModify = presets.get(presetKey);
+            if(presetToModify == null){return;}
+            presetToModify.orderTemplatesByWidth();
     }
 }

--- a/src/test/java/com/gregorybroche/imageresolver/classes/PresetTest.java
+++ b/src/test/java/com/gregorybroche/imageresolver/classes/PresetTest.java
@@ -89,4 +89,16 @@ public class PresetTest {
         assertEquals(testPreset.getTemplates().size(), 2);
         assertTrue(result);
     }
+
+    @Test
+    void orderTemplatesByWidth_shouldOrderTemplateListByDecreasingWidthValue() {
+        Preset testPreset = new Preset("testPreset", new ArrayList<ImageTemplate>());
+        testPreset.addTemplate(template1);
+        testPreset.addTemplate(template2);
+        testPreset.addTemplate(template3);
+        testPreset.orderTemplatesByWidth();
+        assertEquals(testPreset.getTemplates().get(0), template3);
+        assertEquals(testPreset.getTemplates().get(1), template2);
+        assertEquals(testPreset.getTemplates().get(2), template1);
+    }
 }


### PR DESCRIPTION
Added ordering of active preset's template list based on width on initial load and on both add and edit actions. (no need for delete as this event will not cause inversion of previous ordering)